### PR TITLE
klighd.piccolo: fixed performance waste in 'KlighdStyledText'

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KlighdStyledText.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KlighdStyledText.java
@@ -361,7 +361,7 @@ public class KlighdStyledText extends KlighdNode.KlighdFigureNode<KText> {
     protected void updateBounds() {
         // do the (re-)computation of the figure's (local) bounds lazily during the next request,
         //  the indication to do so is done by setting the local bounds 'empty'!
-        getBoundsReference().resetToZero();
+        super.getBoundsReference().resetToZero();
 
         // CAUTION: I intentionally do no call 'invalidateFullBounds'
         //  as this will traverse up the parents and flag all as 'childBoundsInvalid',


### PR DESCRIPTION
Hey guys, please give this change a try. I hope it improves diagram rendering performance significantly and does no harm.