### PR TITLE
klighd +.piccolo: enabled support of multiple KTexts per KLabel as demanded in #43

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.kgraph/src/de/cau/cs/kieler/klighd/kgraph/util/KGraphUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd.kgraph/src/de/cau/cs/kieler/klighd/kgraph/util/KGraphUtil.java
@@ -153,12 +153,6 @@ public final class KGraphUtil {
                 if (node.getInsets() == null) {
                     node.setInsets(FACTORY.createKInsets());
                 }
-            // Make sure labels are OK
-            } else if (element instanceof KLabel) {
-                KLabel label = (KLabel) element;
-                if (label.getText() == null) {
-                    label.setText("");
-                }
             // Make sure edges are OK
             } else if (element instanceof KEdge) {
                 KEdge edge = (KEdge) element;

--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/controller/DiagramController.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/controller/DiagramController.java
@@ -148,6 +148,9 @@ public class DiagramController {
     /** whether edges are drawn before nodes, i.e. nodes have priority over edges. */
     private final boolean edgesFirst;
 
+    /** whether figure descriptions of KLabels may contain multiple KTexts. */
+    private final boolean multipleKTextsPerKLabel;
+
     /** whether to record layout changes, will be set to true by the KlighdLayoutManager. */
     private boolean record = false;
 
@@ -175,6 +178,7 @@ public class DiagramController {
             final ViewContext viewContext) {
         this(graph, camera, sync,
                 getProperty(viewContext, KlighdProperties.EDGES_FIRST).booleanValue(),
+                getProperty(viewContext, KlighdProperties.MULTIPLE_KTEXTS_PER_KLABEL).booleanValue(),
                 getProperty(viewContext, KlighdProperties.ZOOM_TO_FIT_CONTENT_SPACING));
 
         camera.initClipsPortAndLabelsVisibility(
@@ -199,13 +203,22 @@ public class DiagramController {
      * @param edgesFirst
      *            determining whether edges are drawn before nodes, i.e. nodes have priority over
      *            edges
+     * @param multipleKTextsPerKLabel
+     *            whether figure descriptions of KLabels may contain multiple KTexts.
+     * @param defaultZoomToFitContentSpacing
+     *            default spacing to be applied if {@link ZoomStyle#ZOOM_TO_FIT_CONTENT} is
+     *            demanded, see also
+     *            {@link de.cau.cs.kieler.klighd.util.KlighdProperties#ZOOM_TO_FIT_CONTENT_SPACING},
+     *            may be <code>null</code>
      */
-    protected DiagramController(final KNode graph, final KlighdMainCamera camera, final boolean sync,
-            final boolean edgesFirst, final Spacing defaultZoomToFitContentSpacing) {
+    protected DiagramController(final KNode graph, final KlighdMainCamera camera,
+            final boolean sync, final boolean edgesFirst, final boolean multipleKTextsPerKLabel,
+            final Spacing defaultZoomToFitContentSpacing) {
         DiagramControllerHelper.resetGraphElement(graph);
 
         this.sync = sync;
         this.edgesFirst = edgesFirst;
+        this.multipleKTextsPerKLabel = multipleKTextsPerKLabel;
 
         this.canvasCamera = camera;
 
@@ -1884,7 +1897,7 @@ public class DiagramController {
         if (renderingController == null) {
             // the new rendering controller is attached to nodeRep in the constructor of
             //  AbstractRenderingController
-            renderingController = new KLabelRenderingController(labelRep);
+            renderingController = new KLabelRenderingController(labelRep, multipleKTextsPerKLabel);
             // labelRep.addAttribute(RENDERING_KEY, renderingController);
             renderingController.initialize(this, sync);
         } else {

--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KLabelNode.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KLabelNode.java
@@ -34,7 +34,7 @@ public class KLabelNode extends KGraphElementNode<KLabel> {
     private KLabelRenderingController renderingController;
 
     /** the text. */
-    private String text = "";
+    private String text = null;
 
     /**
      * Constructs a Piccolo2D node for representing a {@code KLabel}.

--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KlighdStyledText.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KlighdStyledText.java
@@ -150,7 +150,7 @@ public class KlighdStyledText extends KlighdNode.KlighdFigureNode<KText> {
      *            The text string to be displayed.
      */
     public void setText(final String theText) {
-        this.text = theText;
+        this.text = theText == null ? "" : theText;
         updateBounds();
     }
 

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
@@ -75,6 +75,8 @@ import de.cau.cs.kieler.klighd.krendering.KRendering;
 import de.cau.cs.kieler.klighd.krendering.KRenderingFactory;
 import de.cau.cs.kieler.klighd.krendering.KRenderingOptions;
 import de.cau.cs.kieler.klighd.krendering.KRenderingRef;
+import de.cau.cs.kieler.klighd.krendering.KRenderingUtil;
+import de.cau.cs.kieler.klighd.krendering.KText;
 import de.cau.cs.kieler.klighd.labels.management.LabelManagementResult;
 import de.cau.cs.kieler.klighd.microlayout.Bounds;
 import de.cau.cs.kieler.klighd.microlayout.PlacementUtil;
@@ -552,9 +554,19 @@ public class KlighdDiagramLayoutConnector implements IDiagramLayoutConnector {
             final ElkGraphElement layoutLabeledElement, final boolean estimateSize,
             final boolean setFontLayoutOptions) {
         
+        final KText kText = Iterators.getNext(
+                Iterators.filter(
+                        KRenderingUtil.selfAndAllChildren(label.getData(KRendering.class)),
+                        KText.class),
+                null);
+
+        final String labelText =
+                label.getText() != null ? label.getText()
+                        : kText != null ? kText.getText() : "";
+
         final ElkLabel layoutLabel =
-                ElkGraphUtil.createLabel(label.getText(), layoutLabeledElement);
-        
+                ElkGraphUtil.createLabel(labelText, layoutLabeledElement);
+
         KIdentifier id = label.getData(KIdentifier.class);
         if (id != null && !Strings.isNullOrEmpty(id.getId())) {
             layoutLabel.setIdentifier(id.getId());

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -98,7 +98,7 @@ public final class KlighdProperties {
      * {@link de.cau.cs.kieler.klighd.kgraph.KGraphElement KGraphElement} (kge) into the corresponding
      * diagram if the value is true.<br>
      * This property is currently to be attached to the kge's
-     * {@link de.cau.cs.kieler.kiml.klayoutdata.KLayoutData } data during the view synthesis process.
+     * {@link de.cau.cs.kieler.klighd.kgraph.KLayoutData KLayoutData} data during the view synthesis process.
      * If it is absent the kge is incorporated, anyway.
      */
     public static final IProperty<Boolean> SHOW = new Property<Boolean>(
@@ -256,8 +256,8 @@ public final class KlighdProperties {
      * Property determining whether the diagram zoom scale-based visibility configurations of the
      * {@link de.cau.cs.kieler.klighd.krendering.KRendering KRendering} it is defined on shall apply
      * to its children, as well. Configuring this property on {@link KGraphElement KGraphElements}
-     * (' {@link KLayoutData}) will have no effect, {@link KGraphElement KGraphElements'} children
-     * are automatically skipped by default.
+     * (' {@link de.cau.cs.kieler.klighd.kgraph.KLayoutData KLayoutData}) will have no effect,
+     * {@link KGraphElement KGraphElements'} children are automatically skipped by default.
      */
     public static final IProperty<Boolean> VISIBILITY_PROPAGATE_TO_CHILDREN = new Property<Boolean>(
             "de.cau.cs.kieler.klighd.visibilityPropagateToChildren", false);
@@ -307,6 +307,16 @@ public final class KlighdProperties {
      */
     public static final IProperty<Boolean> EDGES_FIRST = new Property<Boolean>(
             "klighd.edgesFirst", false);
+
+    /**
+     * Property for globally determining whether figure descriptions of
+     * {@link de.cau.cs.kieler.klighd.kgraph.KLabel KLabel}s may contain multiple KTexts. Enabling
+     * this has implications on the applicability of layout algorithms performing the computation of
+     * the label size on their own, as well as the on the applicability of
+     * {@link org.eclipse.elk.core.labels.ILabelManager ILabelManager}s.
+     */
+    public static final IProperty<Boolean> MULTIPLE_KTEXTS_PER_KLABEL = new Property<Boolean>(
+            "klighd.multipleKTextsPerKLabel", false);
 
     /**
      * Determines whether the ports and port labels of clipped nodes should be shown or not.


### PR DESCRIPTION
* introduced guarding property 'MULTIPLE_KTEXTS_PER_KLABEL' preserving the existing behavior by default if not explicitly set to 'true'
* relaxed handling of label text, may now be specified within the first KText alternatively
* dropped dead code as discussed in #54