### PR TITLE
klighd: Make sure calling getDelegate() in ReinitializingDiagramSynthesisProxy always creates the instance first.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/syntheses/ReinitializingDiagramSynthesisProxy.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/syntheses/ReinitializingDiagramSynthesisProxy.java
@@ -233,6 +233,9 @@ public class ReinitializingDiagramSynthesisProxy<S> implements ISynthesis {
      * @return the delegate
      */
     public AbstractDiagramSynthesis<S> getDelegate() {
+        if (this.transformationDelegate == null) {
+            this.transformationDelegate = getNewDelegateInstance();
+        }
         return this.transformationDelegate;
     }
     


### PR DESCRIPTION
Fixes #61 