### PR TITLE
New Method for KPort and KNode Extensions

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.krendering.extensions/src/de/cau/cs/kieler/klighd/krendering/extensions/KNodeExtensions.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.krendering.extensions/src/de/cau/cs/kieler/klighd/krendering/extensions/KNodeExtensions.xtend
@@ -74,6 +74,14 @@ class KNodeExtensions {
     def boolean nodeExists(Object... os) {
         getInternalNodeMap.containsKey(newArrayList(os))
     }
+    
+    /**
+     * A convenient method to register a node that was not created via the create extension.
+     * @return the previous node associated with the given object(s), or {@code null} if there was no node.
+     */
+    def KNode registerExistingNode(KNode node, Object... os) {
+        return getInternalNodeMap.put(newArrayList(os), node)
+    }
 
     /**
      * A convenient getter preserving the element image relation by a create extension.

--- a/plugins/de.cau.cs.kieler.klighd.krendering.extensions/src/de/cau/cs/kieler/klighd/krendering/extensions/KPortExtensions.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.krendering.extensions/src/de/cau/cs/kieler/klighd/krendering/extensions/KPortExtensions.xtend
@@ -106,6 +106,14 @@ class KPortExtensions {
     }
     
     /**
+     * A convenient method to register a port that was not created via the create extension.
+     * @return the previous port associated with the given object(s), or {@code null} if there was no port yet.
+     */
+    def KPort registerExistingPort(KPort port, Object... os) {
+        return getInternalPortMap.put(newArrayList(os), port)
+    }
+    
+    /**
      * A convenient port getter based on a single business object preserving the
      * element image relation by a create extension.
      */


### PR DESCRIPTION
Added new method for KPort and KNode extensions to register nodes/ports that were not create with the create method but should be available via the getters.