### PR TITLE
Disappearing Toolbar Items

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.ui.view/src/de/cau/cs/kieler/klighd/ui/view/DiagramView.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui.view/src/de/cau/cs/kieler/klighd/ui/view/DiagramView.java
@@ -894,8 +894,6 @@ public final class DiagramView extends DiagramViewPart implements ISelectionChan
             // Update toolbar and menu
             toolBarManager.update(false);
             menuManager.updateAll(false);
-            // Update ActionBars important for correct toolbar layout
-            getViewSite().getActionBars().updateActionBars();
 
             // Activate new controller
             simpleUpdate = true;


### PR DESCRIPTION
In the Eclipse 2020-09 release the toolbar of the diagram view looses all its item as soon as an editor is switched. This commit fixes this issue.
However, the responsible code has the comment "_important for correct toolbar layout_". I guess I added it for a reason but I could not reproduce the problem that requires this line of code. Hence, in 2020-09 this line breaks the toolbar, in 2020-06 and 2020-03 this line makes no difference (tested) and probably in some previous release it was necessary.

I would say we want to have this bugfix anyway but you might want to check that it has no consequences for earlier releases that are important to you.
