### PR TITLE
Changed default status handling to 'log', and show exceptions during synthesis transformations to the user.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/Klighd.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/Klighd.java
@@ -89,7 +89,7 @@ public class Klighd {
     }
     
     public static void handle(IStatus status) {
-        getStatusManager().handle(status, IKlighdStatusManager.NONE);
+        getStatusManager().handle(status, IKlighdStatusManager.LOG);
     }
     
     public static void log(IStatus status) {

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/ViewContext.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/ViewContext.java
@@ -460,8 +460,7 @@ public class ViewContext extends MapPropertyHolder {
                         + " failed for input model " + sourceModel.toString() + ".";
 
                 Klighd.handle(
-                        new Status(IStatus.ERROR, Klighd.PLUGIN_ID, msg, e),
-                        IKlighdStatusManager.LOG | IKlighdStatusManager.SHOW);
+                        new Status(IStatus.ERROR, Klighd.PLUGIN_ID, msg, e));
                 return false;
             }
 

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/ViewContext.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/ViewContext.java
@@ -460,7 +460,8 @@ public class ViewContext extends MapPropertyHolder {
                         + " failed for input model " + sourceModel.toString() + ".";
 
                 Klighd.handle(
-                        new Status(IStatus.ERROR, Klighd.PLUGIN_ID, msg, e));
+                        new Status(IStatus.ERROR, Klighd.PLUGIN_ID, msg, e),
+                        IKlighdStatusManager.LOG | IKlighdStatusManager.SHOW);
                 return false;
             }
 


### PR DESCRIPTION
Previously, any code calling `Klighd.handle(IStatus)` caused the status and possible warnings and exceptions within to not be shown anywhere. This alters that behavior, so that the status is at least logged, matching the default behavior of the previoulsy used Eclipse StatusManager's `handle(IStatus)` method.

Furthermore, this shows an exception being thrown during a synthesis to the user in addition to logging it, so that errors during syntheses can be tracked down more easily.