### PR TITLE
AWT Font Size Handling in Offscreen Redering

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/Klighd.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/Klighd.java
@@ -46,6 +46,7 @@ public class Klighd {
     private static IKlighdStatusManager statusManager;
     
     private static boolean suppressDisplayScaleCompensationWhileHandlingText = false;
+    private static boolean simulateSwtFontSizeInAwt = true;
     
     static {
         boolean isLinux = false;
@@ -128,7 +129,31 @@ public class Klighd {
      *            <code>true</code> if compensation shall be suppressed, <code>false</code> reverts
      *            to the default.
      */
-    public static void setSuppressDisplayScaleCompensationWhileHandlingText(boolean suppress) {
+    public static void setSuppressDisplayScaleCompensationWhileHandlingText(final boolean suppress) {
         suppressDisplayScaleCompensationWhileHandlingText = suppress;
+    }
+    
+    /**
+     * Returns the (global) setting on adjusting the font size estimation of AWT to match SWT sizes
+     * more closely. This also enables using px instead of pt when rendering SVGs.
+     * 
+     * @return <code>true</code> if simulation is active and fonts will be scaled (default),
+     *         <code>false</code> otherwise.
+     */
+    public static boolean simulateSwtFontSizeInAwt() {
+        return simulateSwtFontSizeInAwt;
+    }
+
+    /**
+     * Changes the (global) setting on adjusting adjusting the font size estimation of AWT to match SWT sizes
+     * more closely. This also enables using px instead of pt when rendering SVGs.
+     * This setting will only affect non-UI applications, but may be switched off if default AWT font sizes and values
+     * in pt are preferred.
+     *
+     * @param simulate
+     *            <code>true</code> if font sizes should be adjusted, <code>false</code> to deactivate this behavior.
+     */
+    public static void setSimulateSwtFontSizeInAwt(final boolean simulate) {
+        simulateSwtFontSizeInAwt = simulate;
     }
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/microlayout/PlacementUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/microlayout/PlacementUtil.java
@@ -245,7 +245,7 @@ public final class PlacementUtil {
     // CHECKSTYLEON Visibility
 
     private static final KRenderingPackage KRENDERING_PACKAGE = KRenderingPackage.eINSTANCE;
-
+    private static final float PT_TO_PX_FACTOR = KlighdConstants.DEFAULT_DISPLAY_DPI / 72f;
 
     /**
      * Evaluates a position inside given parent bounds.
@@ -934,10 +934,11 @@ public final class PlacementUtil {
     public static Bounds estimateTextSize(final KText kText, final String text) {
         final Bounds testSize = getTestingTextSize(kText);
 
-        if (testSize != null)
+        if (testSize != null) {
             return testSize;
-        else
+        } else {
             return estimateTextSize(fontDataFor(kText, null), text);
+        }
     }
     
     /**
@@ -1090,6 +1091,11 @@ public final class PlacementUtil {
             textBounds.width = 0f; // omit the width in this case
         } else {
             textBounds = new Bounds(fm.getStringBounds(text, fmg));
+        }
+        
+        if (Klighd.simulateSwtFontSizeInAwt()) {
+            textBounds.width  *= PT_TO_PX_FACTOR;
+            textBounds.height *= PT_TO_PX_FACTOR;
         }
         
         return textBounds;


### PR DESCRIPTION
Added global switch to activate scaling factor AWT fonts to match SWT sizes.
Also adjusted svg renderer to use pixel sizes in offscreen mode.