### PR TITLE
Fix missing synthesis options during LSP initialization throws a NullPointerException

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramUpdater.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramUpdater.xtend
@@ -33,6 +33,7 @@ import java.util.HashSet
 import java.util.List
 import java.util.Map
 import java.util.concurrent.CompletableFuture
+import org.apache.log4j.Logger
 import org.eclipse.elk.core.data.LayoutMetaDataService
 import org.eclipse.elk.core.data.LayoutOptionData
 import org.eclipse.elk.core.data.LayoutOptionData.Visibility
@@ -46,7 +47,6 @@ import org.eclipse.sprotty.xtext.ILanguageAwareDiagramServer
 import org.eclipse.sprotty.xtext.ls.DiagramLanguageServer
 import org.eclipse.sprotty.xtext.ls.DiagramUpdater
 import org.eclipse.xtext.util.CancelIndicator
-import org.apache.log4j.Logger
 
 /**
  * Connection between {@link IDiagramServer} and the {@link DiagramLanguageServer}. With this singleton diagram updater,


### PR DESCRIPTION
During the LSP initialization process a client is able to specify persisted synthesis options. If no synthesis options are provided, the server currently throws (and catches) a `NullPointerException` "Could not load client-side synthesis options" and continues to generates a diagram with default synthesis options anyway.
However, a client is not always able to provide synthesis options, which makes the exception slightly irritating in such situations. For example, a KEITH Theia ide that is used for the first time or has cleared `localStorage` does not have persisted options.

This PR prevents the `NullPointException` by using an empty `synthesisOptions` object if necessary.