### PR TITLE
Add node title property to KTexts

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
@@ -117,6 +117,10 @@ class EObjectSerializer implements JsonSerializer<EObject> {
                         jsonObject.add("calculatedTextLineHeights", context.serialize(
                             propertyHolder.<float[]>getProperty(SprottyProperties.CALCULATED_TEXT_LINE_HEIGHTS)))
                     }
+					if (propertyHolder.hasProperty(KlighdProperties.IS_NODE_TITLE)) {
+                        jsonObject.add("isNodeTitle", context.serialize(
+                            propertyHolder.getProperty(KlighdProperties.IS_NODE_TITLE)))
+                    }
                 }
             }
             // All renderings may have tooltips and rendering IDs again.

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -357,4 +357,12 @@ public final class KlighdProperties {
      */
     public static final IProperty<Bounds> CALCULATED_TEXT_BOUNDS =
             new Property<Bounds>("klighd.calculated.text.bounds", null);
+
+	    
+    /**
+     * Determines whether a KText can be interpreted as a title for a node.
+     * By default the KText is not a title.
+     */
+    public static final IProperty<Boolean> IS_NODE_TITLE =
+            new Property<Boolean>("klighd.isNodeTitle", false);
 }


### PR DESCRIPTION
Adds property to KLighD that syntheses may use to indicate a text within renderings of a node to be the quasi-label of it to be displayed instead of the usual renderings in very zoomed out scenarios, as used for the browsing project in KEITH.

Same as #80, but with master as the goal and up to date changes that really happened in this PR.