### PR TITLE
lsp: switched to lazy tracing of diagram elements.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramModule.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramModule.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018,2019 by
+ * Copyright 2018-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -14,6 +14,7 @@ package de.cau.cs.kieler.klighd.lsp
 
 import com.google.inject.Module
 import de.cau.cs.kieler.klighd.lsp.utils.KeithDiagramSelectionListener
+import de.cau.cs.kieler.klighd.lsp.utils.LazyTraceProvider
 import de.cau.cs.kieler.klighd.lsp.utils.SimpleTraceRegionProvider
 import org.eclipse.sprotty.IDiagramSelectionListener
 import org.eclipse.sprotty.xtext.DefaultDiagramModule
@@ -50,6 +51,10 @@ class KGraphDiagramModule extends DefaultDiagramModule {
     
 	def Class<? extends TextRegionProvider> bindTraceRegionProvider() {
         SimpleTraceRegionProvider
+    }
+    
+    override bindTraceProvider() {
+        LazyTraceProvider
     }
     
     override bindIDiagramServerFactory() {

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramState.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramState.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018,2020 by
+ * Copyright 2018-2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -12,6 +12,7 @@
  */
 package de.cau.cs.kieler.klighd.lsp
 
+import com.google.common.collect.BiMap
 import com.google.gson.JsonElement
 import com.google.inject.Singleton
 import de.cau.cs.kieler.klighd.IViewer
@@ -50,7 +51,7 @@ class KGraphDiagramState {
      * Convenient for finding a specific key KGraphElement faster.
      * Mapped by the URI this map belongs to.
      */
-    Map<String, Map<KGraphElement, SModelElement>> kGraphToSModelElementMap = new HashMap
+    Map<String, BiMap<KGraphElement, SModelElement>> kGraphToSModelElementMap = new HashMap
     
     /**
      * A map that contains a key-value pair for each ID of a graph element and the {@link KGraphElement} it identifies.
@@ -142,7 +143,7 @@ class KGraphDiagramState {
      * 
      * @param uri The identifying URI of the graph to access the value in the map.
      */
-    def Map<KGraphElement, SModelElement> getKGraphToSModelElementMap(String uri) {
+    def BiMap<KGraphElement, SModelElement> getKGraphToSModelElementMap(String uri) {
         kGraphToSModelElementMap.get(uri)
     }
     
@@ -152,7 +153,7 @@ class KGraphDiagramState {
      * @param uri The identifying URI of the graph to access the map.
      * @param value The value to be stored in the map.
      */
-    def putKGraphToSModelElementMap(String uri, Map<KGraphElement, SModelElement> value) {
+    def putKGraphToSModelElementMap(String uri, BiMap<KGraphElement, SModelElement> value) {
         kGraphToSModelElementMap.put(uri, value)
     }
     

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramUpdater.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramUpdater.xtend
@@ -274,11 +274,6 @@ class KGraphDiagramUpdater extends DiagramUpdater {
         // Generate the SGraph model from the KGraph model and store every later relevant part in the
         // diagram state.
         val diagramGenerator = diagramGeneratorProvider.get
-        var shouldSelectText = false
-        if (languageServer instanceof KGraphLanguageServerExtension) {
-            shouldSelectText = languageServer.shouldSelectText
-        }
-        diagramGenerator.activeTracing = shouldSelectText
         val sGraph = diagramGenerator.toSGraph(viewContext.viewModel, uri, cancelIndicator)
         synchronized (diagramState) {
             diagramState.putKGraphToSModelElementMap(uri, diagramGenerator.getKGraphToSModelElementMap)

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KeithDiagramSelectionListener.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KeithDiagramSelectionListener.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2019 by
+ * Copyright 2019, 2021 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -12,11 +12,16 @@
  */
 package de.cau.cs.kieler.klighd.lsp.utils
 
+import com.google.inject.Inject
+import de.cau.cs.kieler.klighd.lsp.KGraphDiagramState
 import de.cau.cs.kieler.klighd.lsp.KGraphLanguageServerExtension
 import org.eclipse.sprotty.Action
 import org.eclipse.sprotty.IDiagramServer
+import org.eclipse.sprotty.SModelIndex
+import org.eclipse.sprotty.SelectAction
 import org.eclipse.sprotty.xtext.DiagramSelectionListener
 import org.eclipse.sprotty.xtext.LanguageAwareDiagramServer
+import org.eclipse.sprotty.xtext.tracing.ITraceProvider
 
 /**
  * Extends Sprotty's {@link DiagramSelectionListener} by first checking the configurable option in Keith that indicates
@@ -25,18 +30,46 @@ import org.eclipse.sprotty.xtext.LanguageAwareDiagramServer
  * @author nre
  */
 class KeithDiagramSelectionListener extends DiagramSelectionListener {
+    
+    /**
+     * Stores data for the generation of diagrams.
+     */
+    @Inject
+    KGraphDiagramState diagramState
+    
+    /**
+     * Provider to lazily trace the requested elements.
+     */
+    @Inject
+    ITraceProvider traceProvider
+    
     override selectionChanged(Action action, IDiagramServer server) {
-        // Find out if the selection should be displayed in the text editor.
         if (server instanceof LanguageAwareDiagramServer) {
             val languageServer = server.diagramLanguageServer
             if (languageServer instanceof KGraphLanguageServerExtension) {
+                // Find out if the selection should be displayed in the text editor.
                 if (!languageServer.shouldSelectText) {
                     // If not, return and do nothing.
                     return
                 }
+                // Make sure the lazy tracing has been executed for the selected elements first.
+                if (action instanceof SelectAction && traceProvider instanceof LazyTraceProvider) {
+                    val index = new SModelIndex(server.model)
+                    synchronized (diagramState) {
+                        val s2k = diagramState.getKGraphToSModelElementMap(server.model.id)?.inverse
+                        for (id : (action as SelectAction).selectedElementsIDs ?: #[]) {
+                            val selectedElement = index.get(id)
+                            if (selectedElement.trace === null) {
+                                val selectedKElement = s2k.get(selectedElement)
+                                (traceProvider as LazyTraceProvider).traceFromKGraph(selectedElement, selectedKElement)
+                            }
+                        }
+                    }
+                }
             }
         }
-        // Otherwise, display the selection in the text editor.
+        
         super.selectionChanged(action, server)
     }
+    
 }

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/LazyTraceProvider.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/LazyTraceProvider.xtend
@@ -1,0 +1,93 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ * 
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2021 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This code is provided under the terms of the Eclipse Public License (EPL).
+ */
+package de.cau.cs.kieler.klighd.lsp.utils
+
+import com.google.inject.Inject
+import de.cau.cs.kieler.klighd.internal.util.KlighdInternalProperties
+import de.cau.cs.kieler.klighd.kgraph.KGraphElement
+import de.cau.cs.kieler.klighd.lsp.KGraphDiagramState
+import java.util.Map
+import org.eclipse.emf.common.util.URI
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.sprotty.SModelElement
+import org.eclipse.sprotty.xtext.tracing.XtextTrace
+import org.eclipse.sprotty.xtext.tracing.XtextTraceProvider
+import org.eclipse.xtext.resource.XtextResource
+
+/**
+ * Trace provider that lazily traces elements only when a trace is requested.
+ * 
+ * @author nre
+ */
+class LazyTraceProvider extends XtextTraceProvider {
+    
+    /**
+     * Stores data for the generation of diagrams.
+     */
+    @Inject
+    protected KGraphDiagramState diagramState
+
+    override protected void doFindSModelElement(SModelElement root, Map<URI, EObject> uri2container,
+        (EObject, SModelElement)=>void result) {
+        synchronized (diagramState) {
+            val s2k = diagramState.getKGraphToSModelElementMap(root.id)?.inverse
+            doFindSModelElement2(root, s2k, uri2container, result)
+        }
+    }
+    
+    /**
+     * Finds all SModelElements matching to some trace in {@code uri2container} and applies {@code result} on all
+     * matches. Additionally generates the trace in the first place, if if was not generated before.
+     */
+    protected def void doFindSModelElement2(SModelElement element, Map<SModelElement, KGraphElement> s2k,
+        Map<URI, EObject> uri2container, (EObject, SModelElement)=>void result) {
+        // If there is no trace yet, try to fill it now.
+        if (element.trace === null) {
+            val kElement = s2k.get(element)
+            if (kElement !== null) {
+                traceFromKGraph(element, kElement)
+            }
+        }
+        
+        if (element.trace !== null) {
+            val trace = new XtextTrace(element.trace)
+            val candidate = uri2container.get(trace.elementURI)
+            if (candidate !== null)
+                result.apply(candidate, element)
+        }
+        element.children?.forEach [
+            doFindSModelElement2(s2k, uri2container, result)
+        ]
+    }
+    
+    /**
+     * Generates a trace for the {@code kElement}'s source EObject on the {@code sElement}. 
+     * The kElement must be synthesized by a KLighD synthesis before and must have its source EObject stored in the 
+     * {@link KlighdInternalProperties#MODEL_ELEMEMT} property.
+     * 
+     * @param sElement The SModelElement that needs a trace to its model element.
+     * @param kElement The KGraphElement that was generated from some model element.
+     */
+    def void traceFromKGraph(SModelElement sElement, KGraphElement kElement) {
+        // The real model element that can be traced is the EObject that got synthesized in the
+        // {@link KGraphDiagramGenerator#translateModel} function. That model element has to be stored in the properties
+        // during the synthesis. Otherwise the tracing will not work.
+        val modelElement = kElement.properties.get(KlighdInternalProperties.MODEL_ELEMEMT)
+        if (modelElement instanceof EObject) {
+            if (modelElement.eResource instanceof XtextResource) {
+                trace(sElement, modelElement)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
If the element trace on SModelElements is required for tracing from text
to the diagram or vice versa the traces are now generated lazily only
when they are needed. This speeds up the initial diagram generation
time, especially for very large graphs, where the
PositionConverter#toPosition has an O(n^2) runtime in the model size
because it runs through every character of the model for every model
element.
Tracing from diagram to text is now fast, text to diagram still goes
through the all traces and suffers from above mentioned bad runtime for
very large graphs.

Closes #57.
Closes #90.