### PR TITLE
klighd.piccolo: fixes issue of missing updates of cached bounds on label and port layers

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KGraphElementNode.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KGraphElementNode.java
@@ -166,6 +166,28 @@ public abstract class KGraphElementNode<T extends KGraphElement> extends KlighdN
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setVisible(boolean isVisible) {
+        final boolean visible = getVisible();
+        super.setVisible(isVisible);
+
+        // in case edges/labels/ports with high 'x' or 'y' coordinate values were set invisible
+        //  and smaller width and/or height have been assigned to the parent node
+        // the containing edgeLayer/labelLayer/portLayer will keep the former potentially larger size,
+        //  as no 'invalidate bounds' event is raised on the containing layer by the default impl
+        // those over-sized full bounds will than propagate to the parent kNodeNode and potentially further upward
+        // this is not a problem for correctly drawing the diagram, but it will impair the
+        //  zooming and panning via 'IViewer.reveal(...)' or 'IViewer.centerOn(...)'.
+        // the following 'invalidateFullBounds' should fix that for edges, labels, and ports
+        //  shall be in sync with KNodeAbstractNode.setVisible(boolean)
+        if (visible != isVisible && getParent() != null) {
+            getParent().invalidateFullBounds();
+        }
+    }
+
+    /**
      * {@inheritDoc}<br>
      * <br>
      * KLighD contributes a visibility check in this method.<br>

--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KNodeAbstractNode.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KNodeAbstractNode.java
@@ -183,6 +183,28 @@ public abstract class KNodeAbstractNode extends KlighdDisposingLayer implements
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setVisible(boolean isVisible) {
+        final boolean visible = getVisible();
+        super.setVisible(isVisible);
+
+        // in case edges/labels/ports with high 'x' or 'y' coordinate values were set invisible
+        //  and smaller width and/or height have been assigned to the parent node
+        // the containing edgeLayer/labelLayer/portLayer will keep the former potentially larger size,
+        //  as no 'invalidate bounds' event is raised on the containing layer by the default impl
+        // those over-sized full bounds will than propagate to the parent kNodeNode and potentially further upward
+        // this is not a problem for correctly drawing the diagram, but it will impair the
+        //  zooming and panning via 'IViewer.reveal(...)' or 'IViewer.centerOn(...)'.
+        // the following 'invalidateFullBounds' should fix that for (child) nodes
+        //  shall be in sync with KGraphElementNode.setVisible(boolean)
+        if (visible != isVisible && getParent() != null) {
+            getParent().invalidateFullBounds();
+        }
+    }
+
+    /**
      * Returns whether the diagram is clipped to the represented {@link KNode} and its ports are hidden.
      * 
      * @return <code>true</code> if the diagram is clipped to the represented {@link KNode} and its

--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KlighdDisposingLayer.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/nodes/KlighdDisposingLayer.java
@@ -91,6 +91,32 @@ public class KlighdDisposingLayer extends PLayer implements IKlighdNode {
     }
     
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PBounds getUnionOfChildrenBounds(PBounds dstBounds) {
+        // cs: had to copy the entire method for adding the 'if (each.getVisible())' guard
+        final PBounds resultBounds;
+        if (dstBounds == null) {
+            resultBounds = new PBounds();
+        }
+        else {
+            resultBounds = dstBounds;
+            resultBounds.resetToZero();
+        }
+        
+        final int count = getChildrenCount();
+        for (int i = 0; i < count; i++) {
+            final PNode each = (PNode) getChildrenReference().get(i);
+            if (each.getVisible()) { // cs: added this check in order to ignore invisible children while computing the bounding box
+                resultBounds.add(each.getFullBoundsReference());
+            }
+        }
+
+        return resultBounds;
+    }
+    
+    /**
      * {@inheritDoc}<br>
      * <br>
      * This specialization always returns <code>true</code> since instances of this class will


### PR DESCRIPTION
… after turning (most of) the labels & ports invisible (#106)

change is a consequence of the altered implementation of 'IViewer.hide(...)' and 'IViewer.show(...)', see the changes in
f89b47b1dfbe2b2c199bc21bce0224f7ab467956
c5509a69b937d26746969b949287ed44c7a7c65a
e5685e9d4be14d5e23c8b24c710cde0f70385f86
f6c4a902d2c8d6e51a38c8695ef39ef6aaac561e
3fc43aff21bb66104e54e8019bccc49488118cd1