### PR TITLE
remove unused tooltip field from skgraph field and corresponding references

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
@@ -254,7 +254,6 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
         val nodeElement = configSElement(SKNode, idGen.getId(node))
 
         nodeElement.size = new Dimension(node.width, node.height)
-        nodeElement.tooltip = node.getProperty(KlighdProperties.TOOLTIP)
         val filteredData = node.data.filter [
             KRendering.isAssignableFrom(it.class) || KRenderingLibrary.isAssignableFrom(it.class)
         ].toList
@@ -311,7 +310,6 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
         val SKEdge edgeElement = configSElement(SKEdge, idGen.getId(edge))
         edgeElement.sourceId = idGen.getId(edge.source)
         edgeElement.targetId = idGen.getId(edge.target)
-        edgeElement.tooltip = edge.getProperty(KlighdProperties.TOOLTIP)
 
         val renderings = edge.data.filter[KRendering.isAssignableFrom(it.class)].toList
         
@@ -333,7 +331,6 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
      */
     protected def SKPort generatePort(KPort port) {
         val SKPort portElement = configSElement(SKPort, idGen.getId(port))
-        portElement.tooltip = port.getProperty(KlighdProperties.TOOLTIP)
         
         val renderings = port.data.filter [ KRendering.isAssignableFrom(it.class)].toList
         
@@ -354,7 +351,6 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
      */
     protected def SKLabel generateLabel(KLabel label) {
         val SKLabel labelElement = configSElement(SKLabel, idGen.getId(label))
-        labelElement.tooltip = label.getProperty(KlighdProperties.TOOLTIP)
         labelElement.text = label.text
 
         val renderings = label.data.filter[KRendering.isAssignableFrom(it.class)].toList

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphIncrementalDiagramGenerator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphIncrementalDiagramGenerator.xtend
@@ -223,7 +223,6 @@ class KGraphIncrementalDiagramGenerator extends KGraphDiagramGenerator {
         val nodeElement = configSElement(SKNode, idGen.getId(node))
         
         nodeElement.size = new Dimension(node.width, node.height)
-        nodeElement.tooltip = node.getProperty(KlighdProperties.TOOLTIP)
         val filteredData = node.data.filter [
             KRendering.isAssignableFrom(it.class) || KRenderingLibrary.isAssignableFrom(it.class)
         ].toList

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/KGraphModel.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/KGraphModel.xtend
@@ -52,7 +52,6 @@ class SKNode extends SNode implements SKElement {
     List<KGraphData> data
     HashMap<String, Object> properties = newHashMap
     Direction direction
-    String tooltip
 }
 
 /**
@@ -64,7 +63,6 @@ class SKNode extends SNode implements SKElement {
 @Accessors
 class SKLabel extends SLabel implements SKElement {
     List<KGraphData> data
-    String tooltip
     HashMap<String, Object> properties = newHashMap
 }
 
@@ -77,7 +75,6 @@ class SKLabel extends SLabel implements SKElement {
 @Accessors
 class SKEdge extends SEdge implements SKElement {
     List<KGraphData> data
-    String tooltip
     KVectorChain junctionPoints
     HashMap<String, Object> properties = newHashMap
 }
@@ -91,7 +88,6 @@ class SKEdge extends SEdge implements SKElement {
 @Accessors
 class SKPort extends SPort implements SKElement {
     List<KGraphData> data
-    String tooltip
     HashMap<String, Object> properties = newHashMap
 }
 


### PR DESCRIPTION
Server-side changes corresponding to these [client-side changes](https://github.com/kieler/klighd-vscode/pull/76)

Removes no longer required tooltip field from SKGraph model