### PR TITLE
Make Language Server more robust against problems with SWT

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2021 by
+ * Copyright 2018-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -31,6 +31,7 @@ import de.cau.cs.kieler.klighd.lsp.interactive.rectpacking.RectpackingInteractiv
 import de.cau.cs.kieler.klighd.lsp.launch.AbstractLanguageServer
 import de.cau.cs.kieler.klighd.lsp.model.CheckImagesAction
 import de.cau.cs.kieler.klighd.lsp.model.CheckedImagesAction
+import de.cau.cs.kieler.klighd.lsp.model.DisplayedActionUIData
 import de.cau.cs.kieler.klighd.lsp.model.LayoutOptionUIData
 import de.cau.cs.kieler.klighd.lsp.model.PerformActionAction
 import de.cau.cs.kieler.klighd.lsp.model.RefreshDiagramAction
@@ -197,7 +198,7 @@ class KGraphDiagramServer extends LanguageAwareDiagramServer {
                     synthesisOptions.add(new ValuedSynthesisOption(option, currentValue))
                 }
                 val layoutOptionUIData = calculateLayoutOptionUIData(viewContext.displayedLayoutOptions)
-                val actionData = viewContext.displayedActions
+                val actionData = viewContext.displayedActions.map[new DisplayedActionUIData(it)]
                 dispatch(new UpdateDiagramOptionsAction(synthesisOptions, layoutOptionUIData, actionData, uri))
             }
         }

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2021 by
+ * Copyright 2018-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -16,7 +16,6 @@
  */
 package de.cau.cs.kieler.klighd.lsp.model
 
-import de.cau.cs.kieler.klighd.DisplayedActionData
 import de.cau.cs.kieler.klighd.krendering.KImage
 import java.util.List
 import java.util.Set
@@ -115,7 +114,7 @@ class UpdateDiagramOptionsAction implements Action {
     /**
      * The list of all displayed actions.
      */
-    List<DisplayedActionData> actions
+    List<DisplayedActionUIData> actions
     
     /**
      * The uri for identifying the model these options are for.
@@ -131,7 +130,7 @@ class UpdateDiagramOptionsAction implements Action {
      * Constructor to call when creating this.
      */
     new(List<ValuedSynthesisOption> valuedSynthesisOptions, List<LayoutOptionUIData> layoutOptions,
-        List<DisplayedActionData> actions, String modelUri) {
+        List<DisplayedActionUIData> actions, String modelUri) {
         this.valuedSynthesisOptions = valuedSynthesisOptions
         this.layoutOptions = layoutOptions
         this.actions = actions

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/OptionMessageData.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/OptionMessageData.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018 by
+ * Copyright 2018-2022 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -19,6 +19,7 @@ package de.cau.cs.kieler.klighd.lsp.model
 import de.cau.cs.kieler.klighd.DisplayedActionData
 import de.cau.cs.kieler.klighd.SynthesisOption
 import java.util.List
+import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.Data
 
 // This is a collection of data classes needed for communication with the client.
@@ -164,4 +165,21 @@ class ValuedSynthesisOption {
      * The current value of the synthesisOption.
      */
     Object currentValue
+}
+
+/**
+ * Data class to hold data for actions displayed in the diagram sidebar. Simpler version of {@link DisplayedActionData}
+ * without references to possible SWT objects.
+ */
+@Accessors(PUBLIC_GETTER)
+class DisplayedActionUIData {
+    String actionId
+    String displayedName
+    String tooltipText
+    
+    new(DisplayedActionData data) {
+        this.actionId = data.actionId
+        this.displayedName = data.displayedName
+        this.tooltipText = data.tooltipText
+    }
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/microlayout/PlacementUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/microlayout/PlacementUtil.java
@@ -1049,7 +1049,14 @@ public final class PlacementUtil {
      * @return the minimal bounds for the string
      */
     public static Bounds estimateTextSize(final FontData fontData, final String text) {
-        final Display display = Display.getCurrent();
+        Display display = null;
+        try {
+            display = Display.getCurrent();
+        } catch (Throwable t) {
+            // Show the error, but continue as normal with the AWT fallback.
+            t.printStackTrace();
+        }
+        
         // if a GC has been instantiated before or a display is available.
         if (gc != null || display != null) {
             return estimateTextSizeSWT(fontData, text, display);


### PR DESCRIPTION
This fixes two issues that were present when executing the Language Server on a system which has problems with calling SWT, for example on new Macs with M2 chips:
- removes the SWT image from being sent to klighd-vscode clients, where it was ignored anyways
- introcudes a try-catch in the text size estimation switch between STW and AWT, where the SWT check could throw and not fall back on AWT metrics instead.