### PR TITLE
Mka/whitelist external properties

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
@@ -86,18 +86,10 @@ class EObjectSerializer implements JsonSerializer<EObject> {
             val propertyHolder = source as KRendering
             
             var properties = propertyHolder.allProperties;
-            var blackList = KlighdDataManager.instance.blacklistedProperties;
-            var whiteList = KlighdDataManager.instance.whitelistedProperties;
             var HashMap<String, Object> copiedPropertyMap = newHashMap
     
             for (propertyKVPair : properties.entrySet()) {
-                if (!KGraphMappingUtil.containsPropertyWithId(blackList, propertyKVPair.key.id) 
-                    && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd")
-                        || propertyKVPair.key.id.startsWith("klighd")
-                        || propertyKVPair.key.id.startsWith("org.eclipse.elk")
-                        || KGraphMappingUtil.containsPropertyWithId(whiteList, propertyKVPair.key.id)
-                    )
-                ) {
+                if (KGraphMappingUtil.keepProperty(propertyKVPair.key)) {
                     copiedPropertyMap.put(propertyKVPair.key.id, propertyKVPair.value)
                 }
             }

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
@@ -87,16 +87,21 @@ class EObjectSerializer implements JsonSerializer<EObject> {
             
             var properties = propertyHolder.allProperties;
             var blackList = KlighdDataManager.instance.blacklistedProperties;
+            var whiteList = KlighdDataManager.instance.whitelistedProperties;
             var HashMap<String, Object> copiedPropertyMap = newHashMap
     
             for (propertyKVPair : properties.entrySet()) {
-                if (!KGraphMappingUtil.containsPropertyWithId(blackList, propertyKVPair.key.id)) {
-                    // TODO: remove this check once https://github.com/kieler/semantics/pull/13 has been merged
-                    if (!propertyKVPair.key.id.equals("de.cau.cs.kieler.sccharts.ui.tracker")) {
-                        copiedPropertyMap.put(propertyKVPair.key.id, propertyKVPair.value)
-                    }
+                if (!KGraphMappingUtil.containsPropertyWithId(blackList, propertyKVPair.key.id) 
+                    && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd")
+                        || propertyKVPair.key.id.startsWith("klighd")
+                        || propertyKVPair.key.id.startsWith("org.eclipse.elk")
+                        || KGraphMappingUtil.containsPropertyWithId(whiteList, propertyKVPair.key.id)
+                    )
+                ) {
+                    copiedPropertyMap.put(propertyKVPair.key.id, propertyKVPair.value)
                 }
             }
+
             jsonObject.add("properties", context.serialize(copiedPropertyMap))
         }
         return jsonObject

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend
@@ -111,17 +111,9 @@ class KGraphMappingUtil {
         // map all properties excepts those that are blacklisted
         // also include external whitelisted properties
         var properties = kEdge.allProperties;
-        var blackList = KlighdDataManager.instance.blacklistedProperties;
-        var whiteList = KlighdDataManager.instance.whitelistedProperties;
 
         for (propertyKVPair : properties.entrySet()) {
-            if (!containsPropertyWithId(blackList, propertyKVPair.key.id) 
-                && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd")
-                    || propertyKVPair.key.id.startsWith("klighd")
-                    || propertyKVPair.key.id.startsWith("org.eclipse.elk")
-                    || containsPropertyWithId(whiteList, propertyKVPair.key.id)
-                )
-            ) {
+            if (keepProperty(propertyKVPair.key)) {
                 skEdge.properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }
@@ -147,17 +139,9 @@ class KGraphMappingUtil {
         skNode.size = new Dimension(kNode.width, kNode.height)
 
         var properties = kNode.allProperties;
-        var blackList = KlighdDataManager.instance.blacklistedProperties;
-        var whiteList = KlighdDataManager.instance.whitelistedProperties;
 
         for (propertyKVPair : properties.entrySet()) {
-            if (!containsPropertyWithId(blackList, propertyKVPair.key.id) 
-                && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd") 
-                    || propertyKVPair.key.id.startsWith("klighd")
-                    || propertyKVPair.key.id.startsWith("org.eclipse.elk")
-                    || containsPropertyWithId(whiteList, propertyKVPair.key.id)
-                )
-            ) {
+            if (keepProperty(propertyKVPair.key)) {
                 skNode.properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }
@@ -177,6 +161,21 @@ class KGraphMappingUtil {
             }
         }
         return false;
+    }
+    
+    /**
+     * Check white- and blacklists whether a property should be kept or not. Properties starting with
+     * "de.cau.cs.kieler.klighd", "klighd" or "org.eclipse.elk" are kept by default unless forbidden by
+     * the blacklist.
+     */
+    static def keepProperty(IProperty<?> property) {
+        var blackList = KlighdDataManager.instance.blacklistedProperties;
+        var whiteList = KlighdDataManager.instance.whitelistedProperties;
+        return !containsPropertyWithId(blackList, property.id) 
+                && (property.id.startsWith("de.cau.cs.kieler.klighd") 
+                    || property.id.startsWith("klighd")
+                    || property.id.startsWith("org.eclipse.elk")
+                    || containsPropertyWithId(whiteList, property.id));
     }
     
     /**
@@ -205,17 +204,9 @@ class KGraphMappingUtil {
         }
         
         var properties = kElement.allProperties;
-        var blackList = KlighdDataManager.instance.blacklistedProperties;
-        var whiteList = KlighdDataManager.instance.whitelistedProperties;
         
         for (propertyKVPair : properties.entrySet()) {
-            if (!containsPropertyWithId(blackList, propertyKVPair.key.id) 
-                && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd")
-                    || propertyKVPair.key.id.startsWith("klighd")
-                    || propertyKVPair.key.id.startsWith("org.eclipse.elk")
-                    || containsPropertyWithId(whiteList, propertyKVPair.key.id)
-                )
-            ) {
+            if (keepProperty(propertyKVPair.key)) {
                 (sElement as SKElement).properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend
@@ -109,15 +109,20 @@ class KGraphMappingUtil {
         skEdge.junctionPoints.offset(new KVector(leftInset, topInset))
 
         // map all properties excepts those that are blacklisted
+        // also include external whitelisted properties
         var properties = kEdge.allProperties;
         var blackList = KlighdDataManager.instance.blacklistedProperties;
+        var whiteList = KlighdDataManager.instance.whitelistedProperties;
 
         for (propertyKVPair : properties.entrySet()) {
-            if (!containsPropertyWithId(blackList, propertyKVPair.key.id)) {
-                // TODO: remove this check once https://github.com/kieler/semantics/pull/13 has been merged
-                if (!propertyKVPair.key.id.equals("de.cau.cs.kieler.sccharts.ui.tracker")) {
-                    skEdge.properties.put(propertyKVPair.key.id, propertyKVPair.value)
-                }
+            if (!containsPropertyWithId(blackList, propertyKVPair.key.id) 
+                && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd")
+                    || propertyKVPair.key.id.startsWith("klighd")
+                    || propertyKVPair.key.id.startsWith("org.eclipse.elk")
+                    || containsPropertyWithId(whiteList, propertyKVPair.key.id)
+                )
+            ) {
+                skEdge.properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }
     }
@@ -143,13 +148,17 @@ class KGraphMappingUtil {
 
         var properties = kNode.allProperties;
         var blackList = KlighdDataManager.instance.blacklistedProperties;
+        var whiteList = KlighdDataManager.instance.whitelistedProperties;
 
         for (propertyKVPair : properties.entrySet()) {
-            if (!containsPropertyWithId(blackList, propertyKVPair.key.id)) {
-                // TODO: remove this check once https://github.com/kieler/semantics/pull/13 has been merged
-                if (!propertyKVPair.key.id.equals("de.cau.cs.kieler.sccharts.ui.tracker")) {
-                    skNode.properties.put(propertyKVPair.key.id, propertyKVPair.value)
-                }
+            if (!containsPropertyWithId(blackList, propertyKVPair.key.id) 
+                && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd") 
+                    || propertyKVPair.key.id.startsWith("klighd")
+                    || propertyKVPair.key.id.startsWith("org.eclipse.elk")
+                    || containsPropertyWithId(whiteList, propertyKVPair.key.id)
+                )
+            ) {
+                skNode.properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }
     }
@@ -197,13 +206,17 @@ class KGraphMappingUtil {
         
         var properties = kElement.allProperties;
         var blackList = KlighdDataManager.instance.blacklistedProperties;
+        var whiteList = KlighdDataManager.instance.whitelistedProperties;
         
         for (propertyKVPair : properties.entrySet()) {
-            if (!containsPropertyWithId(blackList, propertyKVPair.key.id)) {
-                // TODO: remove this check once https://github.com/kieler/semantics/pull/13 has been merged
-                if (!propertyKVPair.key.id.equals("de.cau.cs.kieler.sccharts.ui.tracker")) {
-                        (sElement as SKElement).properties.put(propertyKVPair.key.id, propertyKVPair.value)
-                }
+            if (!containsPropertyWithId(blackList, propertyKVPair.key.id) 
+                && (propertyKVPair.key.id.startsWith("de.cau.cs.kieler.klighd")
+                    || propertyKVPair.key.id.startsWith("klighd")
+                    || propertyKVPair.key.id.startsWith("org.eclipse.elk")
+                    || containsPropertyWithId(whiteList, propertyKVPair.key.id)
+                )
+            ) {
+                (sElement as SKElement).properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }
         

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdDataManager.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdDataManager.java
@@ -678,7 +678,10 @@ public final class KlighdDataManager {
     }
     
     /**
-     * Register a property to the blacklist which forbids the property to be sent to the client.
+     * Register a property to the blacklist which forbids the property to be sent to the client. The blacklist only
+     * applies to properties that would otherwise be included i.e. properties starting with "de.cau.cs.kieler.klighd", 
+     * "klighd" or "org.eclipse.elk" or explicitly whitelisted properties. The  blacklist is applied before the 
+     * whitelist is compared.
      * @param blacklistedProperty The property to be blacklisted.
      * @return KlighdDataManager
      */
@@ -688,7 +691,10 @@ public final class KlighdDataManager {
     }
     
     /**
-     * Register a list of properties to the blacklist which forbids the properties to be sent to the client.
+     * Register a list of properties to the blacklist which forbids the properties to be sent to the client. The blacklist 
+     * only applies to properties that would otherwise be included i.e. properties starting with "de.cau.cs.kieler.klighd", 
+     * "klighd" or "org.eclipse.elk" or explicitly whitelisted properties. The  blacklist is applied before the 
+     * whitelist is compared.
      * @param blacklistedProperty The list of properties to be blacklisted.
      * @return KlighdDataManager
      */
@@ -701,7 +707,9 @@ public final class KlighdDataManager {
     
     /**
      * Register a property to the whitelist which ensures the property will be sent to the client. Properties
-     * added here must be serializable by gson.
+     * added here must be serializable by gson. By default only properties starting with "de.cau.cs.kieler.klighd", 
+     * "klighd" or "org.eclipse.elk" are included. Properties outside this namespace can be included by adding them to 
+     * the whitelist. The whitelist is checked after the blacklist.
      * @param whitelistedProperty The property to be whitelisted.
      * @return KlighdDataManager
      */
@@ -712,7 +720,9 @@ public final class KlighdDataManager {
     
     /**
      * Register a list of properties to the whitelist which ensures these properties will be sent to the client.
-     * It must be ensured that all properties can be serialized by gson.
+     * It must be ensured that all properties can be serialized by gson. By default only properties starting with 
+     * "de.cau.cs.kieler.klighd", "klighd" or "org.eclipse.elk" are included. Properties outside this namespace can be 
+     * included by adding them to the whitelist. The whitelist is checked after the blacklist.
      * @param whitelistedProperties The list of properties to be whitelisted.
      * @return KlighdDataManager
      */

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdDataManager.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdDataManager.java
@@ -240,6 +240,9 @@ public final class KlighdDataManager {
     
     /** the properties that are not allowed to be preserved when sending the skgraph to the client */
     private final List<IProperty<?>> blacklistedProperties = Lists.newArrayList();
+    
+    /** the properties that are outside the klighd/elk namespace that are explicitly allowed to be sent to the client */
+    private final List<IProperty<?>> whitelistedProperties = Lists.newArrayList();
 
     /**
      * A private constructor to prevent instantiation.
@@ -692,6 +695,30 @@ public final class KlighdDataManager {
     public KlighdDataManager registerBlacklistedProperties(Iterable<IProperty<?>> blacklistedProperties) {
         for (IProperty<?> blacklistedProperty : blacklistedProperties) {
             registerBlacklistedProperty(blacklistedProperty);
+        }
+        return this;
+    }
+    
+    /**
+     * Register a property to the whitelist which ensures the property will be sent to the client. Properties
+     * added here must be serializable by gson.
+     * @param whitelistedProperty The property to be whitelisted.
+     * @return KlighdDataManager
+     */
+    public KlighdDataManager registerWhitelistedProperty(IProperty<?> whitelistedProperty) {
+        this.whitelistedProperties.add(whitelistedProperty);
+        return this;
+    }
+    
+    /**
+     * Register a list of properties to the whitelist which ensures these properties will be sent to the client.
+     * It must be ensured that all properties can be serialized by gson.
+     * @param whitelistedProperties The list of properties to be whitelisted.
+     * @return KlighdDataManager
+     */
+    public KlighdDataManager registerWhitelistedProperties(Iterable<IProperty<?>> whitelistedProperties) {
+        for (IProperty<?> whitelistedProperty : whitelistedProperties) {
+            registerWhitelistedProperty(whitelistedProperty);
         }
         return this;
     }
@@ -1184,5 +1211,14 @@ public final class KlighdDataManager {
      */
     public List<IProperty<?>> getBlacklistedProperties() {
         return this.blacklistedProperties;
+    }
+    
+    /**
+     * Returns the list of registered properties that have been whitelisted for being sent to the client.
+     * 
+     * @return the {@link List} of whitelisted properties
+     */
+    public List<IProperty<?>> getWhitelistedProperties() {
+        return this.whitelistedProperties;
     }
 }


### PR DESCRIPTION
This changes which properties are kept for the serialization by default.
Now only klighd and elk properties are included by default. Any additionally desired properties must be registered on a whitelist through the KlighdDataManager. This prevents blind inclusion of properties which might be incompatible and requires users to be more explicit about their own properties that they may wish to include.

The blacklist can be used to forbid any property. This makes the most sense for forbidding properties that are included by default ("de.cau.cs.kieler.klighd*", "klighd*" or "org.eclipse.elk*"). External properties (with other prefixes) are now excluded by default. Adding them to the whitelist explicitly allows them to be added again. The whitelist is checked after the blacklist