### PR TITLE
build: update to ELK 0.8.1

### DIFF
--- a/build/de.cau.cs.kieler.klighd.repository/category.xml
+++ b/build/de.cau.cs.kieler.klighd.repository/category.xml
@@ -65,7 +65,7 @@
 
    <repository-reference location="https://download.eclipse.org/releases/2020-06/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/modeling/mdt/uml2/updates/5.4/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/elk/updates/releases/0.7.1/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/elk/updates/releases/0.8.1/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.22.0/" enabled="true" />
    <repository-reference location="https://xtext.github.io/download/updates/releases/2.1.1/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/" enabled="true" />

--- a/build/de.cau.cs.kieler.klighd.repository/pom.xml
+++ b/build/de.cau.cs.kieler.klighd.repository/pom.xml
@@ -51,7 +51,7 @@
                 <associateSite>https://download.eclipse.org/modeling/mdt/uml2/updates/5.4/</associateSite>
                 <!-- Eclipse Layout Kernel -->
                 <!-- associateSite>http://build.eclipse.org/modeling/elk/updates/nightly/</associateSite -->
-                <associateSite>https://download.eclipse.org/elk/updates/releases/0.7.1/</associateSite>>
+                <associateSite>https://download.eclipse.org/elk/updates/releases/0.8.1/</associateSite>>
                 <!-- Xtext -->
                 <associateSite>https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.22.0/</associateSite>>
                 <associateSite>https://xtext.github.io/download/updates/releases/2.1.1/</associateSite>>

--- a/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-piccolo.target
+++ b/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-piccolo.target
@@ -21,7 +21,7 @@
       <unit id="org.eclipse.elk.sdk.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.source.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.8.1/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform.target
+++ b/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform.target
@@ -21,7 +21,7 @@
       <unit id="org.eclipse.elk.sdk.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.elk.ui.feature.source.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.8.1/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/plugins/de.cau.cs.kieler.klighd/META-INF/services/org.eclipse.elk.core.data.ILayoutMetaDataProvider
+++ b/plugins/de.cau.cs.kieler.klighd/META-INF/services/org.eclipse.elk.core.data.ILayoutMetaDataProvider
@@ -1,0 +1,1 @@
+de.cau.cs.kieler.klighd.KlighdOptions

--- a/plugins/de.cau.cs.kieler.klighd/plugin.xml
+++ b/plugins/de.cau.cs.kieler.klighd/plugin.xml
@@ -71,13 +71,6 @@
       </action>
    </extension>
    <extension
-         point="org.eclipse.elk.core.layoutProviders">
-      <provider
-            class="de.cau.cs.kieler.klighd.KlighdOptions">
-      </provider>
-
-   </extension>
-   <extension
          point="de.cau.cs.kieler.klighd.extensions">
       <startupHook
             class="de.cau.cs.kieler.klighd.KlighdSetup"

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <tycho-version>1.7.0</tycho-version>
     <targetJdk>1.8</targetJdk>
     <xtext-version>2.22.0</xtext-version>
-    <elk-version>0.7.1</elk-version>
+    <elk-version>0.8.1</elk-version>
 
     <!-- chsch: copied from https://eclipse.googlesource.com/recommenders/org.eclipse.recommenders/+/3dae4575d3370da2da25a1cbce3dfcff198f0611/features/pom.xml -->
     <!-- Non-breakable space, as normal spaces are trimmed. -->


### PR DESCRIPTION
Updates the build process to now use ELK 0.8.1. Replaces the removed layoutProviders extension point for the KlighdOptions with the service loader counterpart.