### PR TITLE
piccolo: dispose SWT transform and pattern on dispose.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/KlighdSWTGraphicsImpl.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/KlighdSWTGraphicsImpl.java
@@ -1098,6 +1098,10 @@ public class KlighdSWTGraphicsImpl extends Graphics2D implements KlighdSWTGraphi
             image.dispose();
         }
         images.clear();
+        swtTransform.dispose();
+        if (this.lastPattern != null) {
+            this.lastPattern.dispose();
+        }
     }
 
 


### PR DESCRIPTION
This fixes two causes of exceptions that may be thrown because of
undisposed resources and follows the SWT API for these classes,
requesting to be disposed explicitly.