### PR TITLE
Semantic filtering and tagging API

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.klighd/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: KIELER Lightweight Diagrams (KLighD)
 Bundle-SymbolicName: de.cau.cs.kieler.klighd;singleton:=true
-Bundle-Version: 2.2.1.qualifier
+Bundle-Version: 2.1.1.qualifier
 Bundle-Vendor: Kiel University
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: de.cau.cs.kieler.klighd.kgraph,
@@ -21,6 +21,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-Activator: de.cau.cs.kieler.klighd.KlighdPlugin
 Export-Package: de.cau.cs.kieler.klighd,
  de.cau.cs.kieler.klighd.actions,
+ de.cau.cs.kieler.klighd.filtering,
  de.cau.cs.kieler.klighd.internal;x-friends:="de.cau.cs.kieler.klighd.piccolo,de.cau.cs.kieler.klighd.ui,de.cau.cs.kieler.klighd.lsp",
  de.cau.cs.kieler.klighd.internal.macrolayout;x-friends:="de.cau.cs.kieler.klighd.ui,de.cau.cs.kieler.klighd.piccolo",
  de.cau.cs.kieler.klighd.internal.preferences;x-internal:=true,

--- a/plugins/de.cau.cs.kieler.klighd/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.klighd/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: KIELER Lightweight Diagrams (KLighD)
 Bundle-SymbolicName: de.cau.cs.kieler.klighd;singleton:=true
-Bundle-Version: 2.1.1.qualifier
+Bundle-Version: 2.2.1.qualifier
 Bundle-Vendor: Kiel University
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: de.cau.cs.kieler.klighd.kgraph,

--- a/plugins/de.cau.cs.kieler.klighd/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.klighd/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Bundle-Activator: de.cau.cs.kieler.klighd.KlighdPlugin
 Export-Package: de.cau.cs.kieler.klighd,
  de.cau.cs.kieler.klighd.actions,
  de.cau.cs.kieler.klighd.filtering,
+ de.cau.cs.kieler.klighd.filtering.parser,
  de.cau.cs.kieler.klighd.internal;x-friends:="de.cau.cs.kieler.klighd.piccolo,de.cau.cs.kieler.klighd.ui,de.cau.cs.kieler.klighd.lsp",
  de.cau.cs.kieler.klighd.internal.macrolayout;x-friends:="de.cau.cs.kieler.klighd.ui,de.cau.cs.kieler.klighd.piccolo",
  de.cau.cs.kieler.klighd.internal.preferences;x-internal:=true,

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdOptions.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdOptions.java
@@ -16,7 +16,9 @@
  */
 package de.cau.cs.kieler.klighd;
 
+import java.util.Collection;
 import java.util.EnumSet;
+import java.util.List;
 
 import org.eclipse.elk.core.data.ILayoutMetaDataProvider;
 import org.eclipse.elk.core.data.LayoutOptionData;
@@ -24,6 +26,8 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.Property;
 
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterRule;
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterTag;
 import de.cau.cs.kieler.klighd.labels.management.LabelManagementResult;
 import de.cau.cs.kieler.klighd.util.ExpansionAwareLayoutOption;
 

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdOptions.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdOptions.java
@@ -16,9 +16,7 @@
  */
 package de.cau.cs.kieler.klighd;
 
-import java.util.Collection;
 import java.util.EnumSet;
-import java.util.List;
 
 import org.eclipse.elk.core.data.ILayoutMetaDataProvider;
 import org.eclipse.elk.core.data.LayoutOptionData;
@@ -26,8 +24,6 @@ import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.graph.properties.IProperty;
 import org.eclipse.elk.graph.properties.Property;
 
-import de.cau.cs.kieler.klighd.filtering.SemanticFilterRule;
-import de.cau.cs.kieler.klighd.filtering.SemanticFilterTag;
 import de.cau.cs.kieler.klighd.labels.management.LabelManagementResult;
 import de.cau.cs.kieler.klighd.util.ExpansionAwareLayoutOption;
 

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/AndConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/AndConnective.java
@@ -1,0 +1,74 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An And Connective takes two rules R1 and R2 and evaluates to true
+ * iff
+ * R1 and R2 evaluate to true.
+ * 
+ * @author mka
+ * @author tik
+ *
+ */
+public class AndConnective extends BinaryConnective {
+    protected static final String NAME = "AND";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     */
+    public AndConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     */
+    public AndConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param ruleName rule name
+     */
+    public AndConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public AndConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/BinaryConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/BinaryConnective.java
@@ -1,0 +1,67 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A binary connective C takes two filter rules R1 and R2 as operands and creates the new rule R1 C R2.
+ * @author mka
+ * @author tik
+ *
+ */
+public abstract class BinaryConnective extends SemanticFilterRule {
+    
+    protected String name;
+    protected SemanticFilterRule leftOperand;
+    protected SemanticFilterRule rightOperand;
+    
+    /**
+     * {@inheritDoc}
+     */
+    public BinaryConnective() {
+        
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public BinaryConnective(Boolean defaultValue) {
+        super(defaultValue);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public BinaryConnective(String ruleName) {
+        super(ruleName);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public BinaryConnective(Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+    }
+    
+    /**
+     * Returns a string representation of the rule of the form 'C(R1, R2)'.
+     * @return the rule string
+     */
+    public String toString() {
+        return name + "(" + leftOperand + ", " + rightOperand + ")";
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/FalseConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/FalseConnective.java
@@ -1,0 +1,62 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A False Connective always evaluates to false.
+ * 
+ * @author mka
+ *
+ */
+public class FalseConnective extends NullaryConnective {
+
+    protected static final String NAME = "FALSE";
+    
+    /**
+     * Constructor for unnamed rule.
+     */
+    public FalseConnective() {
+        this(null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param defaultValue
+     */
+    public FalseConnective(Boolean defaultValue) {
+        this(defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param ruleName
+     */
+    public FalseConnective(String ruleName) {
+        this(null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param defaultValue
+     * @param ruleName
+     */
+    public FalseConnective(Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
@@ -32,7 +32,7 @@ protected static final String NAME = "GREATEREQUALS";
  * @param leftOperand left operand
  * @param rightOperand right operand
  */
-public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+public GreaterEqualsConnective(NumericResult leftOperand, NumericResult rightOperand) {
     this(leftOperand, rightOperand, null, null);
 }
 
@@ -42,7 +42,7 @@ public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRul
  * @param rightOperand right operand
  * @param defaultValue the default value
  */
-public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+public GreaterEqualsConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue) {
     this(leftOperand, rightOperand, defaultValue, null);
 }
 
@@ -52,7 +52,7 @@ public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRul
  * @param rightOperand right operand
  * @param ruleName rule name
  */
-public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+public GreaterEqualsConnective(NumericResult leftOperand, NumericResult rightOperand, String ruleName) {
     this(leftOperand, rightOperand, null, ruleName);
 }
 
@@ -63,11 +63,11 @@ public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRul
  * @param defaultValue the default value
  * @param ruleName rule name
  */
-public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+public GreaterEqualsConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue, String ruleName) {
     super(defaultValue, ruleName);
     this.name = NAME;
-    this.leftOperand = leftOperand;
-    this.rightOperand = rightOperand;
+    this.leftOperand = (SemanticFilterRule) leftOperand;
+    this.rightOperand = (SemanticFilterRule) rightOperand;
 }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
@@ -31,7 +31,7 @@ protected static final String NAME = "GREATEREQUALS";
      * Constructor for unnamed rule.
      * @param operand the operand
      */
-    public GreaterEqualsConnective(SemanticFilterTag operand) {
+    public GreaterEqualsConnective(NumericResult operand) {
         this(operand, null, null);
     }
     
@@ -40,7 +40,7 @@ protected static final String NAME = "GREATEREQUALS";
      * @param operand the operand
      * @param defaultValue the default value
      */
-    public GreaterEqualsConnective(SemanticFilterTag operand, Boolean defaultValue) {
+    public GreaterEqualsConnective(NumericResult operand, Boolean defaultValue) {
         this(operand, defaultValue, null);
     }
     
@@ -49,7 +49,7 @@ protected static final String NAME = "GREATEREQUALS";
      * @param operand the operand
      * @param ruleName rule name
      */
-    public GreaterEqualsConnective(SemanticFilterTag operand, String ruleName) {
+    public GreaterEqualsConnective(NumericResult operand, String ruleName) {
         this(operand, null, ruleName);
     }
     
@@ -59,10 +59,10 @@ protected static final String NAME = "GREATEREQUALS";
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public GreaterEqualsConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+    public GreaterEqualsConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = operand;
+        this.operand = (SemanticFilterRule) operand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
@@ -1,0 +1,68 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A GreaterEquals Connective takes one rule R and evaluates to true
+ * iff
+ * R.num >= correspondingTag.num.
+ * 
+ * @author mka
+ *
+ */
+public class GreaterEqualsConnective extends UnaryConnective {
+protected static final String NAME = "GREATEREQUALS";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public GreaterEqualsConnective(SemanticFilterTag operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public GreaterEqualsConnective(SemanticFilterTag operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public GreaterEqualsConnective(SemanticFilterTag operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public GreaterEqualsConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterEqualsConnective.java
@@ -17,52 +17,57 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A GreaterEquals Connective takes one rule R and evaluates to true
+ * A GreaterEquals Connective takes two numeric rules R1 and R2 and evaluates to true
  * iff
- * R.num >= correspondingTag.num.
+ * R1 >= R2
  * 
  * @author mka
  *
  */
-public class GreaterEqualsConnective extends UnaryConnective {
+public class GreaterEqualsConnective extends BinaryConnective {
 protected static final String NAME = "GREATEREQUALS";
     
-    /**
-     * Constructor for unnamed rule.
-     * @param operand the operand
-     */
-    public GreaterEqualsConnective(NumericResult operand) {
-        this(operand, null, null);
-    }
-    
-    /**
-     * Constructor for unnamed rule with default value.
-     * @param operand the operand
-     * @param defaultValue the default value
-     */
-    public GreaterEqualsConnective(NumericResult operand, Boolean defaultValue) {
-        this(operand, defaultValue, null);
-    }
-    
-    /**
-     * Constructor for named rule.
-     * @param operand the operand
-     * @param ruleName rule name
-     */
-    public GreaterEqualsConnective(NumericResult operand, String ruleName) {
-        this(operand, null, ruleName);
-    }
-    
-    /**
-     * Constructor for named rule with default value.
-     * @param operand the operand
-     * @param defaultValue the default value
-     * @param ruleName rule name
-     */
-    public GreaterEqualsConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
-        super(defaultValue, ruleName);
-        this.name = NAME;
-        this.operand = (SemanticFilterRule) operand;
-    }
+/**
+ * Constructor for unnamed rule.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ */
+public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+    this(leftOperand, rightOperand, null, null);
+}
+
+/**
+ * Constructor for unnamed rule with default value.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param defaultValue the default value
+ */
+public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+    this(leftOperand, rightOperand, defaultValue, null);
+}
+
+/**
+ * Constructor for named rule.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param ruleName rule name
+ */
+public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+    this(leftOperand, rightOperand, null, ruleName);
+}
+
+/**
+ * Constructor for named rule with default value.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param defaultValue the default value
+ * @param ruleName rule name
+ */
+public GreaterEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+    super(defaultValue, ruleName);
+    this.name = NAME;
+    this.leftOperand = leftOperand;
+    this.rightOperand = rightOperand;
+}
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
@@ -31,7 +31,7 @@ public class GreaterThanConnective extends BinaryConnective {
      * @param leftOperand left operand
      * @param rightOperand right operand
      */
-    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+    public GreaterThanConnective(NumericResult leftOperand, NumericResult rightOperand) {
         this(leftOperand, rightOperand, null, null);
     }
     
@@ -41,7 +41,7 @@ public class GreaterThanConnective extends BinaryConnective {
      * @param rightOperand right operand
      * @param defaultValue the default value
      */
-    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+    public GreaterThanConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue) {
         this(leftOperand, rightOperand, defaultValue, null);
     }
     
@@ -51,7 +51,7 @@ public class GreaterThanConnective extends BinaryConnective {
      * @param rightOperand right operand
      * @param ruleName rule name
      */
-    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+    public GreaterThanConnective(NumericResult leftOperand, NumericResult rightOperand, String ruleName) {
         this(leftOperand, rightOperand, null, ruleName);
     }
     
@@ -62,11 +62,11 @@ public class GreaterThanConnective extends BinaryConnective {
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+    public GreaterThanConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.leftOperand = leftOperand;
-        this.rightOperand = rightOperand;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
@@ -17,51 +17,56 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A GreaterThan Connective takes one rule R and evaluates to true
+ * A GreaterThan Connective takes two numeric rules R1 and R2 and evaluates to true
  * iff
- * R.num > correspondingTag.num.
- * @author tik
+ * R1 > R2
+ * @author tik, mka
  *
  */
-public class GreaterThanConnective extends UnaryConnective {
+public class GreaterThanConnective extends BinaryConnective {
     protected static final String NAME = "GREATERTHAN";
     
     /**
      * Constructor for unnamed rule.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      */
-    public GreaterThanConnective(NumericResult operand) {
-        this(operand, null, null);
+    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
     }
     
     /**
      * Constructor for unnamed rule with default value.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param defaultValue the default value
      */
-    public GreaterThanConnective(NumericResult operand, Boolean defaultValue) {
-        this(operand, defaultValue, null);
+    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
     }
     
     /**
      * Constructor for named rule.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param ruleName rule name
      */
-    public GreaterThanConnective(NumericResult operand, String ruleName) {
-        this(operand, null, ruleName);
+    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
     }
     
     /**
      * Constructor for named rule with default value.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public GreaterThanConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
+    public GreaterThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = (SemanticFilterRule) operand;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
@@ -1,0 +1,67 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A GreaterThan Connective takes one rule R and evaluates to true
+ * iff
+ * R.num > correspondingTag.num.
+ * @author tik
+ *
+ */
+public class GreaterThanConnective extends UnaryConnective {
+    protected static final String NAME = "GREATERTHAN";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public GreaterThanConnective(SemanticFilterTag operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public GreaterThanConnective(SemanticFilterTag operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public GreaterThanConnective(SemanticFilterTag operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public GreaterThanConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/GreaterThanConnective.java
@@ -30,7 +30,7 @@ public class GreaterThanConnective extends UnaryConnective {
      * Constructor for unnamed rule.
      * @param operand the operand
      */
-    public GreaterThanConnective(SemanticFilterTag operand) {
+    public GreaterThanConnective(NumericResult operand) {
         this(operand, null, null);
     }
     
@@ -39,7 +39,7 @@ public class GreaterThanConnective extends UnaryConnective {
      * @param operand the operand
      * @param defaultValue the default value
      */
-    public GreaterThanConnective(SemanticFilterTag operand, Boolean defaultValue) {
+    public GreaterThanConnective(NumericResult operand, Boolean defaultValue) {
         this(operand, defaultValue, null);
     }
     
@@ -48,7 +48,7 @@ public class GreaterThanConnective extends UnaryConnective {
      * @param operand the operand
      * @param ruleName rule name
      */
-    public GreaterThanConnective(SemanticFilterTag operand, String ruleName) {
+    public GreaterThanConnective(NumericResult operand, String ruleName) {
         this(operand, null, ruleName);
     }
     
@@ -58,10 +58,10 @@ public class GreaterThanConnective extends UnaryConnective {
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public GreaterThanConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+    public GreaterThanConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = operand;
+        this.operand = (SemanticFilterRule) operand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/IdentityConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/IdentityConnective.java
@@ -1,0 +1,71 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An Identity Connective evaluates its operand. For example ID (R) is equivalent to R.
+ * 
+ * @author mka
+ *
+ */
+public class IdentityConnective extends UnaryConnective {
+
+    protected static final String NAME = "ID";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     */
+    public IdentityConnective(SemanticFilterRule operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     */
+    public IdentityConnective(SemanticFilterRule operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param ruleName rule name
+     */
+    public IdentityConnective(SemanticFilterRule operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public IdentityConnective(SemanticFilterRule operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+    
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/IfThenConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/IfThenConnective.java
@@ -1,0 +1,73 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An IfThen Connective takes two rules R1 and R2 and evaluates to true
+ * iff
+ * R1 evaluates to false or R2 evaluates to true.
+ * 
+ * @author tik
+ *
+ */
+public class IfThenConnective extends BinaryConnective {
+    protected static final String NAME = "IFTHEN";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     */
+    public IfThenConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     */
+    public IfThenConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param ruleName rule name
+     */
+    public IfThenConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public IfThenConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/IfThenElseConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/IfThenElseConnective.java
@@ -1,0 +1,82 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An IfThenElse Connective takes three rules R1, R2 and R3 and evaluates to true
+ * iff
+ * R1 and R2 evaluate to true or R1 evaluates to false and R3 evaluates to true.
+ * 
+ * @author tik
+ *
+ */
+public class IfThenElseConnective extends TernaryConnective {
+    protected static final String NAME = "IFTHENELSE";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param firstOperand first operand
+     * @param secondOperand second operand
+     * @param thirdOperand third operand
+     */
+    public IfThenElseConnective(SemanticFilterRule firstOperand, SemanticFilterRule secondOperand,
+            SemanticFilterRule thirdOperand) {
+        this(firstOperand, secondOperand, thirdOperand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param firstOperand first operand
+     * @param secondOperand second operand
+     * @param thirdOperand third operand
+     * @param defaultValue the default value
+     */
+    public IfThenElseConnective(SemanticFilterRule firstOperand, SemanticFilterRule secondOperand,
+            SemanticFilterRule thirdOperand, Boolean defaultValue) {
+        this(firstOperand, secondOperand, thirdOperand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param firstOperand first operand
+     * @param secondOperand second operand
+     * @param thirdOperand third operand
+     * @param ruleName rule name
+     */
+    public IfThenElseConnective(SemanticFilterRule firstOperand, SemanticFilterRule secondOperand,
+            SemanticFilterRule thirdOperand, String ruleName) {
+        this(firstOperand, secondOperand, thirdOperand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param firstOperand first operand
+     * @param secondOperand second operand
+     * @param thirdOperand third operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public IfThenElseConnective(SemanticFilterRule firstOperand, SemanticFilterRule secondOperand,
+            SemanticFilterRule thirdOperand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.firstOperand = firstOperand;
+        this.secondOperand = secondOperand;
+        this.thirdOperand = thirdOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
@@ -33,7 +33,7 @@ protected static final String NAME = "LESSEQUALS";
  * @param leftOperand left operand
  * @param rightOperand right operand
  */
-public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+public LessEqualsConnective(NumericResult leftOperand, NumericResult rightOperand) {
     this(leftOperand, rightOperand, null, null);
 }
 
@@ -43,7 +43,7 @@ public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule r
  * @param rightOperand right operand
  * @param defaultValue the default value
  */
-public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+public LessEqualsConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue) {
     this(leftOperand, rightOperand, defaultValue, null);
 }
 
@@ -53,7 +53,7 @@ public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule r
  * @param rightOperand right operand
  * @param ruleName rule name
  */
-public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+public LessEqualsConnective(NumericResult leftOperand, NumericResult rightOperand, String ruleName) {
     this(leftOperand, rightOperand, null, ruleName);
 }
 
@@ -64,11 +64,11 @@ public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule r
  * @param defaultValue the default value
  * @param ruleName rule name
  */
-public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+public LessEqualsConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue, String ruleName) {
     super(defaultValue, ruleName);
     this.name = NAME;
-    this.leftOperand = leftOperand;
-    this.rightOperand = rightOperand;
+    this.leftOperand = (SemanticFilterRule) leftOperand;
+    this.rightOperand = (SemanticFilterRule) rightOperand;
 }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
@@ -17,53 +17,58 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- *  * A LessEquals Connective takes one rule R and evaluates to true
+ * A LessEquals Connective takes two numeric rules R1 and R2 and evaluates to true
  * iff
- * R.num <= correspondingTag.num.
+ * R1 <= R2
  * 
  * @author mka
  *
  */
-public class LessEqualsConnective extends UnaryConnective {
+public class LessEqualsConnective extends BinaryConnective {
     
 protected static final String NAME = "LESSEQUALS";
     
-    /**
-     * Constructor for unnamed rule.
-     * @param operand the operand
-     */
-    public LessEqualsConnective(NumericResult operand) {
-        this(operand, null, null);
-    }
-    
-    /**
-     * Constructor for unnamed rule with default value.
-     * @param operand the operand
-     * @param defaultValue the default value
-     */
-    public LessEqualsConnective(NumericResult operand, Boolean defaultValue) {
-        this(operand, defaultValue, null);
-    }
-    
-    /**
-     * Constructor for named rule.
-     * @param operand the operand
-     * @param ruleName rule name
-     */
-    public LessEqualsConnective(NumericResult operand, String ruleName) {
-        this(operand, null, ruleName);
-    }
-    
-    /**
-     * Constructor for named rule with default value.
-     * @param operand the operand
-     * @param defaultValue the default value
-     * @param ruleName rule name
-     */
-    public LessEqualsConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
-        super(defaultValue, ruleName);
-        this.name = NAME;
-        this.operand = (SemanticFilterRule) operand;
-    }
+/**
+ * Constructor for unnamed rule.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ */
+public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+    this(leftOperand, rightOperand, null, null);
+}
+
+/**
+ * Constructor for unnamed rule with default value.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param defaultValue the default value
+ */
+public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+    this(leftOperand, rightOperand, defaultValue, null);
+}
+
+/**
+ * Constructor for named rule.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param ruleName rule name
+ */
+public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+    this(leftOperand, rightOperand, null, ruleName);
+}
+
+/**
+ * Constructor for named rule with default value.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param defaultValue the default value
+ * @param ruleName rule name
+ */
+public LessEqualsConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+    super(defaultValue, ruleName);
+    this.name = NAME;
+    this.leftOperand = leftOperand;
+    this.rightOperand = rightOperand;
+}
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
@@ -32,7 +32,7 @@ protected static final String NAME = "LESSEQUALS";
      * Constructor for unnamed rule.
      * @param operand the operand
      */
-    public LessEqualsConnective(SemanticFilterTag operand) {
+    public LessEqualsConnective(NumericResult operand) {
         this(operand, null, null);
     }
     
@@ -41,7 +41,7 @@ protected static final String NAME = "LESSEQUALS";
      * @param operand the operand
      * @param defaultValue the default value
      */
-    public LessEqualsConnective(SemanticFilterTag operand, Boolean defaultValue) {
+    public LessEqualsConnective(NumericResult operand, Boolean defaultValue) {
         this(operand, defaultValue, null);
     }
     
@@ -50,7 +50,7 @@ protected static final String NAME = "LESSEQUALS";
      * @param operand the operand
      * @param ruleName rule name
      */
-    public LessEqualsConnective(SemanticFilterTag operand, String ruleName) {
+    public LessEqualsConnective(NumericResult operand, String ruleName) {
         this(operand, null, ruleName);
     }
     
@@ -60,10 +60,10 @@ protected static final String NAME = "LESSEQUALS";
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public LessEqualsConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+    public LessEqualsConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = operand;
+        this.operand = (SemanticFilterRule) operand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessEqualsConnective.java
@@ -1,0 +1,69 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ *  * A LessEquals Connective takes one rule R and evaluates to true
+ * iff
+ * R.num <= correspondingTag.num.
+ * 
+ * @author mka
+ *
+ */
+public class LessEqualsConnective extends UnaryConnective {
+    
+protected static final String NAME = "LESSEQUALS";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public LessEqualsConnective(SemanticFilterTag operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public LessEqualsConnective(SemanticFilterTag operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public LessEqualsConnective(SemanticFilterTag operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public LessEqualsConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
@@ -30,7 +30,7 @@ public class LessThanConnective extends UnaryConnective {
      * Constructor for unnamed rule.
      * @param operand the operand
      */
-    public LessThanConnective(SemanticFilterTag operand) {
+    public LessThanConnective(NumericResult operand) {
         this(operand, null, null);
     }
     
@@ -39,7 +39,7 @@ public class LessThanConnective extends UnaryConnective {
      * @param operand the operand
      * @param defaultValue the default value
      */
-    public LessThanConnective(SemanticFilterTag operand, Boolean defaultValue) {
+    public LessThanConnective(NumericResult operand, Boolean defaultValue) {
         this(operand, defaultValue, null);
     }
     
@@ -48,7 +48,7 @@ public class LessThanConnective extends UnaryConnective {
      * @param operand the operand
      * @param ruleName rule name
      */
-    public LessThanConnective(SemanticFilterTag operand, String ruleName) {
+    public LessThanConnective(NumericResult operand, String ruleName) {
         this(operand, null, ruleName);
     }
     
@@ -58,10 +58,10 @@ public class LessThanConnective extends UnaryConnective {
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public LessThanConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+    public LessThanConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = operand;
+        this.operand = (SemanticFilterRule) operand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
@@ -17,51 +17,56 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A LessThan Connective takes one rule R and evaluates to true
+ * A LessThan Connective takes two numeric rules R1 and R2 and evaluates to true
  * iff
- * R.num < correspondingTag.num.
- * @author tik
+ * R1 < R2
+ * @author tik, mka
  *
  */
-public class LessThanConnective extends UnaryConnective {
+public class LessThanConnective extends BinaryConnective {
     protected static final String NAME = "LESSTHAN";
     
     /**
      * Constructor for unnamed rule.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      */
-    public LessThanConnective(NumericResult operand) {
-        this(operand, null, null);
+    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
     }
     
     /**
      * Constructor for unnamed rule with default value.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param defaultValue the default value
      */
-    public LessThanConnective(NumericResult operand, Boolean defaultValue) {
-        this(operand, defaultValue, null);
+    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
     }
     
     /**
      * Constructor for named rule.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param ruleName rule name
      */
-    public LessThanConnective(NumericResult operand, String ruleName) {
-        this(operand, null, ruleName);
+    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
     }
     
     /**
      * Constructor for named rule with default value.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public LessThanConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
+    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = (SemanticFilterRule) operand;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
@@ -31,7 +31,7 @@ public class LessThanConnective extends BinaryConnective {
      * @param leftOperand left operand
      * @param rightOperand right operand
      */
-    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+    public LessThanConnective(NumericResult leftOperand, NumericResult rightOperand) {
         this(leftOperand, rightOperand, null, null);
     }
     
@@ -41,7 +41,7 @@ public class LessThanConnective extends BinaryConnective {
      * @param rightOperand right operand
      * @param defaultValue the default value
      */
-    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+    public LessThanConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue) {
         this(leftOperand, rightOperand, defaultValue, null);
     }
     
@@ -51,7 +51,7 @@ public class LessThanConnective extends BinaryConnective {
      * @param rightOperand right operand
      * @param ruleName rule name
      */
-    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+    public LessThanConnective(NumericResult leftOperand, NumericResult rightOperand, String ruleName) {
         this(leftOperand, rightOperand, null, ruleName);
     }
     
@@ -62,11 +62,11 @@ public class LessThanConnective extends BinaryConnective {
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public LessThanConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+    public LessThanConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.leftOperand = leftOperand;
-        this.rightOperand = rightOperand;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LessThanConnective.java
@@ -1,0 +1,67 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A LessThan Connective takes one rule R and evaluates to true
+ * iff
+ * R.num < correspondingTag.num.
+ * @author tik
+ *
+ */
+public class LessThanConnective extends UnaryConnective {
+    protected static final String NAME = "LESSTHAN";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public LessThanConnective(SemanticFilterTag operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public LessThanConnective(SemanticFilterTag operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public LessThanConnective(SemanticFilterTag operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public LessThanConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LogicEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/LogicEqualConnective.java
@@ -1,0 +1,73 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An Equal Connective takes two rules R1 and R2 and evaluates to true
+ * iff
+ * R1 and R2 evaluate to true or R1 and R2 evaluate to false.
+ * 
+ * @author tik
+ *
+ */
+public class LogicEqualConnective extends BinaryConnective {
+    protected static final String NAME = "LOGICEQUAL";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     */
+    public LogicEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     */
+    public LogicEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param ruleName rule name
+     */
+    public LogicEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public LogicEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
+    }
+    
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NegationConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NegationConnective.java
@@ -1,0 +1,69 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A Not Connective takes a rule R and evaluates to true
+ * iff
+ * R evaluates to false.
+ * 
+ * @author mka
+ * @author tik
+ *
+ */
+public class NegationConnective extends UnaryConnective {
+    protected static final String NAME = "NOT";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public NegationConnective(SemanticFilterRule operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public NegationConnective(SemanticFilterRule operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public NegationConnective(SemanticFilterRule operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NegationConnective(SemanticFilterRule operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NullaryConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NullaryConnective.java
@@ -1,0 +1,63 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * @author mka
+ *
+ */
+public abstract class NullaryConnective extends SemanticFilterRule {
+    
+    protected String name;
+    
+    /**
+     * {@inheritDoc}
+     */
+    public NullaryConnective() {
+        
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public NullaryConnective(Boolean defaultValue) {
+        super(defaultValue);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public NullaryConnective(String ruleName) {
+        super(ruleName);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public NullaryConnective(Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+    }
+    
+    /**
+     * Returns a string representation of the rule in the form 'C(R)'.
+     * @return the rule string
+     */
+    public String toString() {
+        return name;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericAdditionConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericAdditionConnective.java
@@ -17,8 +17,8 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A Numeric Divides Connective takes two numeric operands and evaluates
- * to their quotient.
+ * A Numeric Addition Connective takes two numeric operands and evaluates
+ * to their sum.
  * 
  * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
  * connective and should never be treated as a rule and thus does not need a name.
@@ -26,8 +26,8 @@ package de.cau.cs.kieler.klighd.filtering;
  * @author mka
  *
  */
-public class NumericDividesConnective extends BinaryConnective implements NumericResult {
-    protected static final String NAME = "NUMERICDIVIDES";
+public class NumericAdditionConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICADDITION";
     
     /**
      * Constructor for named rule with default value.
@@ -36,7 +36,7 @@ public class NumericDividesConnective extends BinaryConnective implements Numeri
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericDividesConnective(NumericResult leftOperand, NumericResult rightOperand) {
+    public NumericAdditionConnective(NumericResult leftOperand, NumericResult rightOperand) {
         super();
         this.name = NAME;
         this.leftOperand = (SemanticFilterRule) leftOperand;

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericConstantConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericConstantConnective.java
@@ -64,5 +64,10 @@ private Double num;
         this.name = NAME;
         this.num = num;
     }
+    
+    @Override
+    public String toString() {
+        return this.name + "(" + num + ")";
+    }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericConstantConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericConstantConnective.java
@@ -1,0 +1,68 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * Numeric constant for building expressions.
+ * 
+ * @author mka
+ *
+ */
+public class NumericConstantConnective extends NullaryConnective implements NumericResult {
+    
+protected static final String NAME = "CONST";
+private Double num;
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param num
+     */
+    public NumericConstantConnective(Double num) {
+        this(null, null, num);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param defaultValue
+     * @param num
+     */
+    public NumericConstantConnective(Boolean defaultValue, Double num) {
+        this(defaultValue, null, num);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param ruleName
+     * @param num
+     */
+    public NumericConstantConnective(String ruleName, Double num) {
+        this(null, ruleName, num);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param defaultValue
+     * @param ruleName
+     * @param num
+     */
+    public NumericConstantConnective(Boolean defaultValue, String ruleName, Double num) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.num = num;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericDividesConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericDividesConnective.java
@@ -1,0 +1,46 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A Numeric Divides Connective takes two numeric operands and evaluates
+ * to their quotient.
+ * 
+ * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
+ * connective and should never be treated as a rule and thus does not need a name.
+ * 
+ * @author mka
+ *
+ */
+public class NumericDividesConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICDIVIDES";
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NumericDividesConnective(NumericResult leftOperand, NumericResult rightOperand) {
+        super();
+        this.name = NAME;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericDivisionConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericDivisionConnective.java
@@ -17,8 +17,8 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A Numeric Minus Connective takes two numeric operands and evaluates
- * to their difference.
+ * A Numeric Division Connective takes two numeric operands and evaluates
+ * to their quotient.
  * 
  * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
  * connective and should never be treated as a rule and thus does not need a name.
@@ -26,8 +26,8 @@ package de.cau.cs.kieler.klighd.filtering;
  * @author mka
  *
  */
-public class NumericMinusConnective extends BinaryConnective implements NumericResult {
-    protected static final String NAME = "NUMERICMINUS";
+public class NumericDivisionConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICDIVISION";
     
     /**
      * Constructor for named rule with default value.
@@ -36,7 +36,7 @@ public class NumericMinusConnective extends BinaryConnective implements NumericR
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericMinusConnective(NumericResult leftOperand, NumericResult rightOperand) {
+    public NumericDivisionConnective(NumericResult leftOperand, NumericResult rightOperand) {
         super();
         this.name = NAME;
         this.leftOperand = (SemanticFilterRule) leftOperand;

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
@@ -31,7 +31,7 @@ public class NumericEqualConnective extends BinaryConnective {
      * @param leftOperand left operand
      * @param rightOperand right operand
      */
-    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+    public NumericEqualConnective(NumericResult leftOperand, NumericResult rightOperand) {
         this(leftOperand, rightOperand, null, null);
     }
     
@@ -41,7 +41,7 @@ public class NumericEqualConnective extends BinaryConnective {
      * @param rightOperand right operand
      * @param defaultValue the default value
      */
-    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+    public NumericEqualConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue) {
         this(leftOperand, rightOperand, defaultValue, null);
     }
     
@@ -51,7 +51,7 @@ public class NumericEqualConnective extends BinaryConnective {
      * @param rightOperand right operand
      * @param ruleName rule name
      */
-    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+    public NumericEqualConnective(NumericResult leftOperand, NumericResult rightOperand, String ruleName) {
         this(leftOperand, rightOperand, null, ruleName);
     }
     
@@ -62,11 +62,11 @@ public class NumericEqualConnective extends BinaryConnective {
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+    public NumericEqualConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.leftOperand = leftOperand;
-        this.rightOperand = rightOperand;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
@@ -30,7 +30,7 @@ public class NumericEqualConnective extends UnaryConnective {
      * Constructor for unnamed rule.
      * @param operand the operand
      */
-    public NumericEqualConnective(SemanticFilterTag operand) {
+    public NumericEqualConnective(NumericResult operand) {
         this(operand, null, null);
     }
     
@@ -39,7 +39,7 @@ public class NumericEqualConnective extends UnaryConnective {
      * @param operand the operand
      * @param defaultValue the default value
      */
-    public NumericEqualConnective(SemanticFilterTag operand, Boolean defaultValue) {
+    public NumericEqualConnective(NumericResult operand, Boolean defaultValue) {
         this(operand, defaultValue, null);
     }
     
@@ -48,7 +48,7 @@ public class NumericEqualConnective extends UnaryConnective {
      * @param operand the operand
      * @param ruleName rule name
      */
-    public NumericEqualConnective(SemanticFilterTag operand, String ruleName) {
+    public NumericEqualConnective(NumericResult operand, String ruleName) {
         this(operand, null, ruleName);
     }
     
@@ -58,10 +58,10 @@ public class NumericEqualConnective extends UnaryConnective {
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericEqualConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+    public NumericEqualConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = operand;
+        this.operand = (SemanticFilterRule) operand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
@@ -17,51 +17,56 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A NumericEqual Connective takes one rule R and evaluates to true
+ * A NumericEqual Connective takes two rules R1 and R2 and evaluates to true
  * iff
- * R.num == correspondingTag.num.
- * @author tik
+ * R1 == R2
+ * @author tik, mka
  *
  */
-public class NumericEqualConnective extends UnaryConnective {
+public class NumericEqualConnective extends BinaryConnective {
     protected static final String NAME = "NUMERICEQUAL";
     
     /**
      * Constructor for unnamed rule.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      */
-    public NumericEqualConnective(NumericResult operand) {
-        this(operand, null, null);
+    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
     }
     
     /**
      * Constructor for unnamed rule with default value.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param defaultValue the default value
      */
-    public NumericEqualConnective(NumericResult operand, Boolean defaultValue) {
-        this(operand, defaultValue, null);
+    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
     }
     
     /**
      * Constructor for named rule.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param ruleName rule name
      */
-    public NumericEqualConnective(NumericResult operand, String ruleName) {
-        this(operand, null, ruleName);
+    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
     }
     
     /**
      * Constructor for named rule with default value.
-     * @param operand the operand
+     * @param leftOperand left operand
+     * @param rightOperand right operand
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericEqualConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
+    public NumericEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = (SemanticFilterRule) operand;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericEqualConnective.java
@@ -1,0 +1,67 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A NumericEqual Connective takes one rule R and evaluates to true
+ * iff
+ * R.num == correspondingTag.num.
+ * @author tik
+ *
+ */
+public class NumericEqualConnective extends UnaryConnective {
+    protected static final String NAME = "NUMERICEQUAL";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public NumericEqualConnective(SemanticFilterTag operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public NumericEqualConnective(SemanticFilterTag operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public NumericEqualConnective(SemanticFilterTag operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NumericEqualConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericMinusConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericMinusConnective.java
@@ -1,0 +1,46 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A Numeric Minus Connective takes two numeric operands and evaluates
+ * to their difference.
+ * 
+ * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
+ * connective and should never be treated as a rule and thus does not need a name.
+ * 
+ * @author mka
+ *
+ */
+public class NumericMinusConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICMINUS";
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NumericMinusConnective(NumericResult leftOperand, NumericResult rightOperand) {
+        super();
+        this.name = NAME;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericMultiplicationConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericMultiplicationConnective.java
@@ -17,8 +17,8 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A Numeric Plus Connective takes two numeric operands and evaluates
- * to their sum.
+ * A Numeric Multiplication Connective takes two numeric operands and evaluates
+ * to their product.
  * 
  * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
  * connective and should never be treated as a rule and thus does not need a name.
@@ -26,8 +26,8 @@ package de.cau.cs.kieler.klighd.filtering;
  * @author mka
  *
  */
-public class NumericPlusConnective extends BinaryConnective implements NumericResult {
-    protected static final String NAME = "NUMERICPLUS";
+public class NumericMultiplicationConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICMULTIPLICATION";
     
     /**
      * Constructor for named rule with default value.
@@ -36,7 +36,7 @@ public class NumericPlusConnective extends BinaryConnective implements NumericRe
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericPlusConnective(NumericResult leftOperand, NumericResult rightOperand) {
+    public NumericMultiplicationConnective(NumericResult leftOperand, NumericResult rightOperand) {
         super();
         this.name = NAME;
         this.leftOperand = (SemanticFilterRule) leftOperand;

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
@@ -33,7 +33,7 @@ protected static final String NAME = "NUMERICNOTEQUAL";
  * @param leftOperand left operand
  * @param rightOperand right operand
  */
-public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+public NumericNotEqualConnective(NumericResult leftOperand, NumericResult rightOperand) {
     this(leftOperand, rightOperand, null, null);
 }
 
@@ -43,7 +43,7 @@ public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterR
  * @param rightOperand right operand
  * @param defaultValue the default value
  */
-public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+public NumericNotEqualConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue) {
     this(leftOperand, rightOperand, defaultValue, null);
 }
 
@@ -53,7 +53,7 @@ public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterR
  * @param rightOperand right operand
  * @param ruleName rule name
  */
-public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+public NumericNotEqualConnective(NumericResult leftOperand, NumericResult rightOperand, String ruleName) {
     this(leftOperand, rightOperand, null, ruleName);
 }
 
@@ -64,11 +64,11 @@ public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterR
  * @param defaultValue the default value
  * @param ruleName rule name
  */
-public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+public NumericNotEqualConnective(NumericResult leftOperand, NumericResult rightOperand, Boolean defaultValue, String ruleName) {
     super(defaultValue, ruleName);
     this.name = NAME;
-    this.leftOperand = leftOperand;
-    this.rightOperand = rightOperand;
+    this.leftOperand = (SemanticFilterRule) leftOperand;
+    this.rightOperand = (SemanticFilterRule) rightOperand;
 }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
@@ -32,7 +32,7 @@ protected static final String NAME = "NUMERICNOTEQUAL";
      * Constructor for unnamed rule.
      * @param operand the operand
      */
-    public NumericNotEqualConnective(SemanticFilterTag operand) {
+    public NumericNotEqualConnective(NumericResult operand) {
         this(operand, null, null);
     }
     
@@ -41,7 +41,7 @@ protected static final String NAME = "NUMERICNOTEQUAL";
      * @param operand the operand
      * @param defaultValue the default value
      */
-    public NumericNotEqualConnective(SemanticFilterTag operand, Boolean defaultValue) {
+    public NumericNotEqualConnective(NumericResult operand, Boolean defaultValue) {
         this(operand, defaultValue, null);
     }
     
@@ -50,7 +50,7 @@ protected static final String NAME = "NUMERICNOTEQUAL";
      * @param operand the operand
      * @param ruleName rule name
      */
-    public NumericNotEqualConnective(SemanticFilterTag operand, String ruleName) {
+    public NumericNotEqualConnective(NumericResult operand, String ruleName) {
         this(operand, null, ruleName);
     }
     
@@ -60,10 +60,10 @@ protected static final String NAME = "NUMERICNOTEQUAL";
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericNotEqualConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+    public NumericNotEqualConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
         super(defaultValue, ruleName);
         this.name = NAME;
-        this.operand = operand;
+        this.operand = (SemanticFilterRule) operand;
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
@@ -17,53 +17,58 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- *  * A NumericNotEqual Connective takes one rule R and evaluates to true
+ * A NumericNotEqual Connective takes two numeric rules R1 and R2 and evaluates to true
  * iff
- * R.num != correspondingTag.num.
+ * R1 != R2
  * 
  * @author mka
  *
  */
-public class NumericNotEqualConnective extends UnaryConnective {
+public class NumericNotEqualConnective extends BinaryConnective {
     
 protected static final String NAME = "NUMERICNOTEQUAL";
     
-    /**
-     * Constructor for unnamed rule.
-     * @param operand the operand
-     */
-    public NumericNotEqualConnective(NumericResult operand) {
-        this(operand, null, null);
-    }
-    
-    /**
-     * Constructor for unnamed rule with default value.
-     * @param operand the operand
-     * @param defaultValue the default value
-     */
-    public NumericNotEqualConnective(NumericResult operand, Boolean defaultValue) {
-        this(operand, defaultValue, null);
-    }
-    
-    /**
-     * Constructor for named rule.
-     * @param operand the operand
-     * @param ruleName rule name
-     */
-    public NumericNotEqualConnective(NumericResult operand, String ruleName) {
-        this(operand, null, ruleName);
-    }
-    
-    /**
-     * Constructor for named rule with default value.
-     * @param operand the operand
-     * @param defaultValue the default value
-     * @param ruleName rule name
-     */
-    public NumericNotEqualConnective(NumericResult operand, Boolean defaultValue, String ruleName) {
-        super(defaultValue, ruleName);
-        this.name = NAME;
-        this.operand = (SemanticFilterRule) operand;
-    }
+/**
+ * Constructor for unnamed rule.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ */
+public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+    this(leftOperand, rightOperand, null, null);
+}
+
+/**
+ * Constructor for unnamed rule with default value.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param defaultValue the default value
+ */
+public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+    this(leftOperand, rightOperand, defaultValue, null);
+}
+
+/**
+ * Constructor for named rule.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param ruleName rule name
+ */
+public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+    this(leftOperand, rightOperand, null, ruleName);
+}
+
+/**
+ * Constructor for named rule with default value.
+ * @param leftOperand left operand
+ * @param rightOperand right operand
+ * @param defaultValue the default value
+ * @param ruleName rule name
+ */
+public NumericNotEqualConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+    super(defaultValue, ruleName);
+    this.name = NAME;
+    this.leftOperand = leftOperand;
+    this.rightOperand = rightOperand;
+}
 
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericNotEqualConnective.java
@@ -1,0 +1,69 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ *  * A NumericNotEqual Connective takes one rule R and evaluates to true
+ * iff
+ * R.num != correspondingTag.num.
+ * 
+ * @author mka
+ *
+ */
+public class NumericNotEqualConnective extends UnaryConnective {
+    
+protected static final String NAME = "NUMERICNOTEQUAL";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param operand the operand
+     */
+    public NumericNotEqualConnective(SemanticFilterTag operand) {
+        this(operand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     */
+    public NumericNotEqualConnective(SemanticFilterTag operand, Boolean defaultValue) {
+        this(operand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param operand the operand
+     * @param ruleName rule name
+     */
+    public NumericNotEqualConnective(SemanticFilterTag operand, String ruleName) {
+        this(operand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param operand the operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NumericNotEqualConnective(SemanticFilterTag operand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.operand = operand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericPlusConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericPlusConnective.java
@@ -1,0 +1,46 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A Numeric Plus Connective takes two numeric operands and evaluates
+ * to their sum.
+ * 
+ * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
+ * connective and should never be treated as a rule and thus does not need a name.
+ * 
+ * @author mka
+ *
+ */
+public class NumericPlusConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICPLUS";
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NumericPlusConnective(NumericResult leftOperand, NumericResult rightOperand) {
+        super();
+        this.name = NAME;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericResult.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericResult.java
@@ -1,0 +1,28 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * Identifies rules that return a numeric result.
+ * 
+ * @author mka
+ *
+ */
+public interface NumericResult {
+    
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericSubtractionConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericSubtractionConnective.java
@@ -17,8 +17,8 @@
 package de.cau.cs.kieler.klighd.filtering;
 
 /**
- * A Numeric Times Connective takes two numeric operands and evaluates
- * to their product.
+ * A Numeric Subtraction Connective takes two numeric operands and evaluates
+ * to their difference.
  * 
  * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
  * connective and should never be treated as a rule and thus does not need a name.
@@ -26,8 +26,8 @@ package de.cau.cs.kieler.klighd.filtering;
  * @author mka
  *
  */
-public class NumericTimesConnective extends BinaryConnective implements NumericResult {
-    protected static final String NAME = "NUMERICTIMES";
+public class NumericSubtractionConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICSUBSTRACTION";
     
     /**
      * Constructor for named rule with default value.
@@ -36,7 +36,7 @@ public class NumericTimesConnective extends BinaryConnective implements NumericR
      * @param defaultValue the default value
      * @param ruleName rule name
      */
-    public NumericTimesConnective(NumericResult leftOperand, NumericResult rightOperand) {
+    public NumericSubtractionConnective(NumericResult leftOperand, NumericResult rightOperand) {
         super();
         this.name = NAME;
         this.leftOperand = (SemanticFilterRule) leftOperand;

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericTimesConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/NumericTimesConnective.java
@@ -1,0 +1,46 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A Numeric Times Connective takes two numeric operands and evaluates
+ * to their product.
+ * 
+ * Operands must implement {@link NumericResult} and be a {@link SemanticFilterTag}. This connective is an internal
+ * connective and should never be treated as a rule and thus does not need a name.
+ * 
+ * @author mka
+ *
+ */
+public class NumericTimesConnective extends BinaryConnective implements NumericResult {
+    protected static final String NAME = "NUMERICTIMES";
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public NumericTimesConnective(NumericResult leftOperand, NumericResult rightOperand) {
+        super();
+        this.name = NAME;
+        this.leftOperand = (SemanticFilterRule) leftOperand;
+        this.rightOperand = (SemanticFilterRule) rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/OrConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/OrConnective.java
@@ -1,0 +1,74 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An Or Connective takes two rules R1 and R2 and evaluates to true
+ * iff
+ * R1 or R2 evaluate to true.
+ * 
+ * @author mka
+ * @author tik
+ *
+ */
+public class OrConnective extends BinaryConnective {
+    protected static final String NAME = "OR";
+    
+    /**
+     * Constructor for unnamed rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     */
+    public OrConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand) {
+        this(leftOperand, rightOperand, null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     */
+    public OrConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue) {
+        this(leftOperand, rightOperand, defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param ruleName rule name
+     */
+    public OrConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, String ruleName) {
+        this(leftOperand, rightOperand, null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param leftOperand left operand
+     * @param rightOperand right operand
+     * @param defaultValue the default value
+     * @param ruleName rule name
+     */
+    public OrConnective(SemanticFilterRule leftOperand, SemanticFilterRule rightOperand, Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+        this.leftOperand = leftOperand;
+        this.rightOperand = rightOperand;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterRule.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterRule.java
@@ -1,0 +1,86 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * Semantic filter rules describe a filter that can be evaluated to include only elements tagged with certain tags.
+ * The rules are constructed through the combination of filter rules with logical connectives.
+ * 
+ * @author mka
+ * @author tik
+ *
+ */
+public abstract class SemanticFilterRule {
+    
+    /** The rule name is used to identify rules and distinguish them from one another. */
+    private String ruleName;
+    /** The default value is used to indicate whether the semantic filter should be on or off by default. */
+    private Boolean defaultValue;
+    
+    /**
+     * Basic constructor
+     */
+    public SemanticFilterRule() {
+        this(null, null);
+    }
+    
+    /**
+     * Constructor that takes a default value.
+     * The default value is used to indicate whether the semantic filter should be on or off by default.
+     * @param defaultValue the default value
+     */
+    public SemanticFilterRule(Boolean defaultValue) {
+        this(defaultValue, null);
+    }
+    
+    /**
+     * Constructor that takes a rule name.
+     * The rule name is used to identify rules and distinguish them from one another.
+     * @param ruleName the rule name
+     */
+    public SemanticFilterRule(String ruleName) {
+        this(null, ruleName);
+    }
+    
+    /**
+     * Constructor that takes a rule name and default value.
+     * The default value is used to indicate whether the semantic filter should be on or off by default.
+     * The rule name is used to identify rules and distinguish them from one another.
+     * @param defaultValue the default value
+     * @param ruleName the rule name
+     */
+    public SemanticFilterRule(Boolean defaultValue, String ruleName) {
+        this.defaultValue = defaultValue;
+        this.ruleName = ruleName;
+    }
+    
+    /**
+     * Returns the rule name.
+     * @return the rule name
+     */
+    public String getRuleName() { 
+        return this.ruleName;
+    }
+    
+    /**
+     * Returns the default value.
+     * @return the default value
+     */
+    public boolean getDefaultValue() { 
+        return this.defaultValue;
+    }
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterRuleUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterRuleUtil.java
@@ -19,18 +19,10 @@ package de.cau.cs.kieler.klighd.filtering;
 /**
  * Util for easily getting some rules.
  * 
- * @author tik
+ * @author tik, mka
  *
  */
 public abstract class SemanticFilterRuleUtil {
-    /** An empty tag used to define constants. */
-    private static final SemanticFilterTag EMPTY = new SemanticFilterTag("");
-    /** A rule that is always evaluated to false. */
-    public static final SemanticFilterRule FALSE =
-            new AndConnective(EMPTY, new NegationConnective(EMPTY));
-    /** A rule that is always evaluated to true. */
-    public static final SemanticFilterRule TRUE =
-            new OrConnective(EMPTY, new NegationConnective(EMPTY));
 
     /**
      * Constructs an unnamed rule with all operands connected via OR. If no operands are given, this
@@ -58,7 +50,7 @@ public abstract class SemanticFilterRuleUtil {
             SemanticFilterRule... operands) {
         if (operands.length <= 0) {
             // No rules, automatically evaluate to false
-            return FALSE;
+            return new FalseConnective();
         } else if (operands.length <= 1) {
             // Just one rule, true iff rule is true
             // Add ruleName instead of just using first operand twice to avoid double evaluation
@@ -97,7 +89,7 @@ public abstract class SemanticFilterRuleUtil {
             SemanticFilterRule... operands) {
         if (operands.length <= 0) {
             // No rules, automatically evaluate to false
-            return FALSE;
+            return new FalseConnective();
         } else if (operands.length <= 1) {
             // Just one rule, true iff rule is true
             // Add ruleName instead of just using first operand twice to avoid double evaluation
@@ -121,6 +113,6 @@ public abstract class SemanticFilterRuleUtil {
      * @return A named rule.
      */
     public static SemanticFilterRule addRuleName(String ruleName, SemanticFilterRule rule) {
-        return new NegationConnective(new NegationConnective(rule), ruleName);
+        return new IdentityConnective((rule), ruleName);
     }
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterRuleUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterRuleUtil.java
@@ -1,0 +1,126 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * Util for easily getting some rules.
+ * 
+ * @author tik
+ *
+ */
+public abstract class SemanticFilterRuleUtil {
+    /** An empty tag used to define constants. */
+    private static final SemanticFilterTag EMPTY = new SemanticFilterTag("");
+    /** A rule that is always evaluated to false. */
+    public static final SemanticFilterRule FALSE =
+            new AndConnective(EMPTY, new NegationConnective(EMPTY));
+    /** A rule that is always evaluated to true. */
+    public static final SemanticFilterRule TRUE =
+            new OrConnective(EMPTY, new NegationConnective(EMPTY));
+
+    /**
+     * Constructs an unnamed rule with all operands connected via OR. If no operands are given, this
+     * is always false.
+     * 
+     * @param operands
+     *            The operands.
+     * @return The SemanticFilterRule.
+     */
+    public static SemanticFilterRule getBigOrConnective(SemanticFilterRule... operands) {
+        return getBigOrConnective(null, operands);
+    }
+
+    /**
+     * Constructs a named rule with all operands connected via OR. If no operands are given, this is
+     * always false.
+     * 
+     * @param ruleName
+     *            The rule name.
+     * @param operands
+     *            The operands.
+     * @return The SemanticFilterRule.
+     */
+    public static SemanticFilterRule getBigOrConnective(String ruleName,
+            SemanticFilterRule... operands) {
+        if (operands.length <= 0) {
+            // No rules, automatically evaluate to false
+            return FALSE;
+        } else if (operands.length <= 1) {
+            // Just one rule, true iff rule is true
+            // Add ruleName instead of just using first operand twice to avoid double evaluation
+            return addRuleName(ruleName, operands[0]);
+        }
+        OrConnective bigOr = new OrConnective(operands[0], operands[1], ruleName);
+        for (int i = 2; i < operands.length; i++) {
+            bigOr.rightOperand = new OrConnective(bigOr.rightOperand, operands[i]);
+        }
+        return bigOr;
+    }
+
+    /**
+     * Constructs an unnamed rule with all operands connected via AND. If no operands are given,
+     * this is always false.
+     * 
+     * @param operands
+     *            The operands.
+     * @return The SemanticFilterRule.
+     */
+    public static SemanticFilterRule getBigAndConnective(SemanticFilterRule... operands) {
+        return getBigAndConnective(null, operands);
+    }
+
+    /**
+     * Constructs a named rule with all operands connected via AND. If no operands are given, this
+     * is always false.
+     * 
+     * @param ruleName
+     *            The rule name.
+     * @param operands
+     *            The operands.
+     * @return The SemanticFilterRule.
+     */
+    public static SemanticFilterRule getBigAndConnective(String ruleName,
+            SemanticFilterRule... operands) {
+        if (operands.length <= 0) {
+            // No rules, automatically evaluate to false
+            return FALSE;
+        } else if (operands.length <= 1) {
+            // Just one rule, true iff rule is true
+            // Add ruleName instead of just using first operand twice to avoid double evaluation
+            return addRuleName(ruleName, operands[0]);
+        }
+        // Use first operand twice in case of just one rule, e.g. true iff rule is true
+        AndConnective bigAnd = new AndConnective(operands[0], operands[1], ruleName);
+        for (int i = 2; i < operands.length; i++) {
+            bigAnd.rightOperand = new AndConnective(bigAnd.rightOperand, operands[i]);
+        }
+        return bigAnd;
+    }
+
+    /**
+     * Constructs a new named rule from a given potentially unnamed rule.
+     * 
+     * @param ruleName
+     *            The rule name.
+     * @param rule
+     *            The rule.
+     * @return A named rule.
+     */
+    public static SemanticFilterRule addRuleName(String ruleName, SemanticFilterRule rule) {
+        return new NegationConnective(new NegationConnective(rule), ruleName);
+    }
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterTag.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterTag.java
@@ -28,7 +28,7 @@ package de.cau.cs.kieler.klighd.filtering;
  * @author tik
  *
  */
-public class SemanticFilterTag extends SemanticFilterRule {
+public class SemanticFilterTag extends SemanticFilterRule implements NumericResult {
     
     private String tag;
     /** If unset, defaults to 0. */

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterTag.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/SemanticFilterTag.java
@@ -1,0 +1,103 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * Semantic filter tags serve both as tags on graph elements to provide semantic meaning in a diagram that can not 
+ * be conveyed otherwise and as an atomic filter rule that can be combined with other rules to construct more complex
+ * rules.
+ * 
+ * When using a tag in numeric expressions, keep in mind that not defining the number results in it defaulting to 0.
+ * It's best practice to always set the number explicitly, if one can be assigned.
+ * 
+ * @author mka
+ * @author tik
+ *
+ */
+public class SemanticFilterTag extends SemanticFilterRule {
+    
+    private String tag;
+    /** If unset, defaults to 0. */
+    private Double num;
+    
+    /**
+     * Constructor for tag.
+     * @param tag string identifier
+     */
+    public SemanticFilterTag(String tag) {
+        this.tag = tag;
+    }
+    
+    /**
+     * Constructor for tag with a number.
+     * @param tag string identifier
+     * @param num the number
+     */
+    public SemanticFilterTag(String tag, Double num) {
+        this.tag = tag;
+        this.num = num;
+    }
+    
+    /**
+     * Constructor for tag as a semantic filter rule.
+     * Here, an additional rule name is required as this is later used to differentiate between multiple rules.
+     * @param tag string identifier of the tag the rule applies to
+     * @param ruleName string identifier of the rule itself, can be anything
+     */
+    public SemanticFilterTag(String tag, String ruleName) {
+        super(ruleName);
+        this.tag = tag;
+    }
+    
+    /**
+     * Constructor for tag with a number as a semantic filter rule.
+     * Here, an additional rule name is required as this is later used to differentiate between multiple rules.
+     * @param tag string identifier of the tag the rule applies to
+     * @param num the number
+     * @param ruleName string identifier of the rule itself, can be anything
+     */
+    public SemanticFilterTag(String tag, Double num, String ruleName) {
+        super(ruleName);
+        this.tag = tag;
+        this.num = num;
+    }
+    
+    /**
+     * Returns the tag.
+     * @return the tag
+     */
+    public String getTag() {
+        return this.tag;
+    }
+    
+    /**
+     * Returns the num.
+     * @return the num
+     */
+    public Double getNum() {
+        return this.num;
+    }
+
+    /**
+     * Returns a string representation of the rule/tag.
+     * @return the rule string
+     */
+    public String toString() {
+        return "(tag=" + this.tag + ", num=" + this.num + ")";
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/TernaryConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/TernaryConnective.java
@@ -1,0 +1,67 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A ternary connective C takes three filter rules R1, R2 and R3 as operands and creates the new rule C R1 R2 R3.
+ * 
+ * @author tik
+ *
+ */
+public abstract class TernaryConnective extends SemanticFilterRule {
+    
+    protected String name;
+    protected SemanticFilterRule firstOperand;
+    protected SemanticFilterRule secondOperand;
+    protected SemanticFilterRule thirdOperand;
+    
+    /**
+     * {@inheritDoc}
+     */
+    public TernaryConnective() {
+        
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public TernaryConnective(Boolean defaultValue) {
+        super(defaultValue);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public TernaryConnective(String ruleName) {
+        super(ruleName);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public TernaryConnective(Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+    }
+    
+    /**
+     * Returns a string representation of the rule of the form 'C(R1, R2, R3)'.
+     * @return the rule string
+     */
+    public String toString() {
+        return name + "(" + firstOperand + ", " + secondOperand + ", " + thirdOperand + ")";
+    }
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/TrueConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/TrueConnective.java
@@ -1,0 +1,62 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * A True Connective always evaluates to true.
+ * 
+ * @author mka
+ *
+ */
+public class TrueConnective extends NullaryConnective {
+    
+    protected static final String NAME = "TRUE";
+    
+    /**
+     * Constructor for unnamed rule.
+     */
+    public TrueConnective() {
+        this(null, null);
+    }
+    
+    /**
+     * Constructor for unnamed rule with default value.
+     * @param defaultValue
+     */
+    public TrueConnective(Boolean defaultValue) {
+        this(defaultValue, null);
+    }
+    
+    /**
+     * Constructor for named rule.
+     * @param ruleName
+     */
+    public TrueConnective(String ruleName) {
+        this(null, ruleName);
+    }
+    
+    /**
+     * Constructor for named rule with default value.
+     * @param defaultValue
+     * @param ruleName
+     */
+    public TrueConnective(Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+        this.name = NAME;
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/UnaryConnective.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/UnaryConnective.java
@@ -1,0 +1,67 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering;
+
+/**
+ * An unary connective C takes a single filter rule R as an operand and creates the new rule C(R).
+ * 
+ * @author mka
+ * @author tik
+ *
+ */
+public abstract class UnaryConnective extends SemanticFilterRule {
+    
+    protected String name;
+    protected SemanticFilterRule operand;
+    
+    /**
+     * {@inheritDoc}
+     */
+    public UnaryConnective() {
+        
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public UnaryConnective(Boolean defaultValue) {
+        super(defaultValue);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public UnaryConnective(String ruleName) {
+        super(ruleName);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public UnaryConnective(Boolean defaultValue, String ruleName) {
+        super(defaultValue, ruleName);
+    }
+    
+    /**
+     * Returns a string representation of the rule in the form 'C(R)'.
+     * @return the rule string
+     */
+    public String toString() {
+        return name + "(" + this.operand + ")";
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/parser/SemanticFilterRuleParser.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/filtering/parser/SemanticFilterRuleParser.java
@@ -1,0 +1,296 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.filtering.parser;
+
+import static java.util.Map.entry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.StringTokenizer;
+
+import de.cau.cs.kieler.klighd.filtering.AndConnective;
+import de.cau.cs.kieler.klighd.filtering.FalseConnective;
+import de.cau.cs.kieler.klighd.filtering.GreaterEqualsConnective;
+import de.cau.cs.kieler.klighd.filtering.GreaterThanConnective;
+import de.cau.cs.kieler.klighd.filtering.LessEqualsConnective;
+import de.cau.cs.kieler.klighd.filtering.LessThanConnective;
+import de.cau.cs.kieler.klighd.filtering.LogicEqualConnective;
+import de.cau.cs.kieler.klighd.filtering.NegationConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericAdditionConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericConstantConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericDivisionConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericEqualConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericMultiplicationConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericNotEqualConnective;
+import de.cau.cs.kieler.klighd.filtering.NumericResult;
+import de.cau.cs.kieler.klighd.filtering.NumericSubtractionConnective;
+import de.cau.cs.kieler.klighd.filtering.OrConnective;
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterRule;
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterTag;
+import de.cau.cs.kieler.klighd.filtering.TrueConnective;
+
+/**
+ * @author mka
+ *
+ */
+public class SemanticFilterRuleParser {
+    
+    private abstract class Node {
+        public String token;
+        // current return type of AST
+        // -1: unknown
+        // 0: boolean
+        // 1: numeric
+        public int type;
+        public Node(String token, int type) {
+            this.token = token;
+            this.type = type;
+        }
+    }
+    
+    private class OperatorNode extends Node {
+        private List<Node> children;
+        
+        public List<Node> getChildren() { return children; }
+        
+        public OperatorNode(String token, int type) {
+            super(token, type);
+            this.children = new ArrayList<>();
+        }
+        public OperatorNode(String token, int type, List<Node> children) {
+            super(token, type);
+            this.children = children;
+        }
+        
+        public void addChild(Node child) {
+            this.children.add(child);
+        }
+    }
+    
+    private class OperandNode extends Node {
+
+        public OperandNode(String token, int type) {
+            super(token, type);
+        }
+    }
+    
+    public class InvalidSyntaxException extends Exception {
+
+        public InvalidSyntaxException(String message) {
+            super(message);
+        }
+    }
+    
+    private SemanticFilterRule convertAST(Node ast) throws InvalidSyntaxException {
+        try {
+            SemanticFilterRule result;
+            switch(ast.token) {
+            case "*":
+                result = new NumericMultiplicationConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "/":
+                result = new NumericDivisionConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "+":
+                result = new NumericAdditionConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "-":
+                result = new NumericSubtractionConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            // NUMERIC-TO-BOOLEAN
+            case "=":
+                if (ast.type == 0) {
+                    result = new LogicEqualConnective(
+                            convertAST(((OperatorNode)ast).getChildren().get(0)),
+                            convertAST(((OperatorNode)ast).getChildren().get(1)));
+                } else {
+                    result = new NumericEqualConnective(
+                            (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                            (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                }
+                break;
+            case "!=":
+                result = new NumericNotEqualConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case ">=":
+                result = new GreaterEqualsConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case ">":
+                result = new GreaterThanConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "<=":
+                result = new LessEqualsConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "<":
+                result = new LessThanConnective(
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        (NumericResult) convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            // BOOLEAN-TO-BOOLEAN
+            case "||":
+                result = new OrConnective(
+                        convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "&&":
+                result = new AndConnective(
+                        convertAST(((OperatorNode)ast).getChildren().get(0)),
+                        convertAST(((OperatorNode)ast).getChildren().get(1)));
+                break;
+            case "!":
+                result = new NegationConnective(
+                        convertAST(((OperatorNode)ast).getChildren().get(0)));
+                break;
+            case "true":
+                result = new TrueConnective();
+                break;
+            case "false":
+                result = new FalseConnective();
+            default:
+                // variable or number
+                if (ast.token.charAt(0) == '$' || ast.token.charAt(0) == '#') {
+                    result = new SemanticFilterTag(ast.token.substring(1));
+                } else {
+                    result = new NumericConstantConnective(Double.valueOf(ast.token));
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            throw new InvalidSyntaxException("Syntax error.");
+        }
+    }
+    
+    private static List<String> OPERATORS = new ArrayList<>(Arrays.asList(
+            "*", "/", "+", "-", "=", "!=", ">=", ">", "<=", "<", "||", "&&", "!"));
+    private static Map<String, Integer> PRECEDENCES = Map.ofEntries(
+            entry("*", 10),
+            entry("/", 10),
+            entry("+", 9),
+            entry("-", 9),
+            entry("=", 7),
+            entry("!=", 7),
+            entry(">=", 8),
+            entry(">", 8),
+            entry("<=", 8),
+            entry("<", 8),
+            entry("||", 3),
+            entry("&&", 4),
+            entry("!", 6));
+    /**
+     * Parses a semantic filter rule expression and creates the abstract syntax tree i.e., {@link SemanticFilterRule}.
+     * @param ruleString expression
+     * @return AST
+     * @throws InvalidSyntaxException 
+     */
+    public SemanticFilterRule parse(String ruleString) throws InvalidSyntaxException {
+        
+        // Tokenize string
+        StringTokenizer tokenizer = new StringTokenizer(ruleString);
+        Stack<OperatorNode> operatorStack = new Stack<>();
+        Stack<Node> outputStack = new Stack<>();
+        
+        while (tokenizer.hasMoreTokens()) {
+            String token = tokenizer.nextToken();
+            
+            if (OPERATORS.contains(token)) {
+
+                while (!operatorStack.isEmpty() && !operatorStack.peek().token.equals("(") 
+                        && (PRECEDENCES.get(operatorStack.peek().token) > PRECEDENCES.get(token) 
+                                || PRECEDENCES.get(operatorStack.peek().token) == PRECEDENCES.get(token) 
+                                && !token.equals("!"))) {
+                    popOperator(operatorStack, outputStack);
+                }
+                operatorStack.push(new OperatorNode(token,-1));
+                
+            } else if (token.equals("(")) {
+                operatorStack.push(new OperatorNode(token, -1));
+            } else if (token.equals(")")) {
+                if (operatorStack.isEmpty()) {
+                    throw new InvalidSyntaxException("Mismatched parentheses.");
+                }
+                while (!operatorStack.peek().token.equals("(")) {
+                    if (operatorStack.isEmpty()) {
+                        throw new InvalidSyntaxException("Mismatched parentheses.");
+                    }
+                    popOperator(operatorStack, outputStack);
+                }
+                // discard final (
+                operatorStack.pop();
+            } else {
+                // Operand
+                if (token.startsWith("#") || token.equals("true") || token.equals("false")) {
+                    outputStack.push(new OperandNode(token, 0));
+                } else {
+                    // number or variable starting with $
+                    outputStack.push(new OperandNode(token, 1));
+                }
+            }
+        }
+        // pop remaining operators
+        while (!operatorStack.isEmpty()) {
+            popOperator(operatorStack, outputStack);
+        }
+        
+        return convertAST(outputStack.pop());
+    }
+    
+    private void popOperator(Stack<OperatorNode> operatorStack, Stack<Node> outputStack) throws InvalidSyntaxException {
+        // remove operator from operator stack and create new node on output stack
+        OperatorNode operator = operatorStack.pop();
+        if (operator.token.equals("(") || operator.token.equals(")")) {
+            throw new InvalidSyntaxException("Mismatched parentheses.");
+        }
+        if (operator.token.equals("!")) {
+            Node operand = outputStack.pop();
+            operator.addChild(operand);
+            operator.type = 0;
+            outputStack.push(operator);
+        } else {
+            // all other operators are binary
+            Node operand1 = outputStack.pop();
+            Node operand2 = outputStack.pop();
+            // reverse order to get correct final order
+            operator.addChild(operand2);
+            operator.addChild(operand1);
+            if (operand1.type != operand2.type) {
+                throw new InvalidSyntaxException("Mixed use of boolean and numeric types in operator " + operator.token + ".");
+            }
+            operator.type = operand1.type;
+            outputStack.push(operator);
+        }
+    }
+
+}

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -17,6 +17,8 @@
 package de.cau.cs.kieler.klighd.util;
 
 import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.math.Spacing;
@@ -26,6 +28,8 @@ import org.eclipse.elk.graph.properties.Property;
 import org.eclipse.emf.ecore.EObject;
 
 import de.cau.cs.kieler.klighd.KlighdConstants;
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterRule;
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterTag;
 import de.cau.cs.kieler.klighd.kgraph.KGraphElement;
 import de.cau.cs.kieler.klighd.kgraph.KNode;
 import de.cau.cs.kieler.klighd.krendering.KText;
@@ -379,4 +383,20 @@ public final class KlighdProperties {
      */
     public static final IProperty<Boolean> IS_NODE_TITLE =
             new Property<Boolean>("klighd.isNodeTitle", false);
+    
+    /**
+     * Property determining an element's semantic filter tags.
+     */
+    public static final IProperty<List<SemanticFilterTag>> SEMANTIC_FILTER_TAGS = 
+            new Property<List<SemanticFilterTag>>("de.cau.cs.kieler.klighd.semanticFilter.tags",
+                    // ArrayList is cloneable, no problem here
+                    new ArrayList<>());
+
+    /**
+     * Property determining an element's semantic filter rules.
+     * Only relevant for the root.
+     */
+    public static final IProperty<List<SemanticFilterRule>> SEMANTIC_FILTER_RULES = 
+            new Property<List<SemanticFilterRule>>("de.cau.cs.kieler.klighd.semanticFilter.rules",
+                    new ArrayList<>());
 }

--- a/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/SemanticFilteringTest.java
+++ b/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/SemanticFilteringTest.java
@@ -1,0 +1,51 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ * 
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package de.cau.cs.kieler.klighd.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import de.cau.cs.kieler.klighd.filtering.SemanticFilterRule;
+import de.cau.cs.kieler.klighd.filtering.parser.SemanticFilterRuleParser;
+import de.cau.cs.kieler.klighd.filtering.parser.SemanticFilterRuleParser.InvalidSyntaxException;
+
+/**
+ * Tests of classes in {@link de.cau.cs.kieler.klighd.filtering}
+ * 
+ * @author mka
+ *
+ */
+public class SemanticFilteringTest {
+    
+    @Test
+    public void testSimpleExpressions() {
+        try {
+            SemanticFilterRule rule1 = new SemanticFilterRuleParser().parse("#tag1 && #tag2 || #tag3");
+            assertEquals("OR(AND((tag=tag1, num=null), (tag=tag2, num=null)), (tag=tag3, num=null))", rule1.toString());
+            SemanticFilterRule rule2 = new SemanticFilterRuleParser().parse("( #tag1 )");
+            assertEquals("(tag=tag1, num=null)", rule2.toString());
+            SemanticFilterRule rule3 = new SemanticFilterRuleParser().parse("$tag1 + $tag2 > 4");
+            assertEquals("GREATERTHAN(NUMERICADDITION((tag=tag1, num=null), (tag=tag2, num=null)), CONST(4.0))", rule3.toString());
+        } catch (InvalidSyntaxException e) {
+            System.out.println(e.getMessage());
+            fail();
+        }
+    }
+
+}


### PR DESCRIPTION
https://github.com/kieler/klighd-vscode/pull/109

# Wiki Page Draft
## Semantic Filtering Tags
`SemanticFilterTag`s can be added to a graph element with the property `de.cau.cs.kieler.klighd.semanticFilter.tags`. They contain a string that serves to convey semantic information. A tag also acts as an atomic `SemanticFilterRule` that evaluates to true for an element if that element contains a tag with the same string.

## Semantic Filtering Rules
A graph element can contain a list of `SemanticFilterRule`s. Depending on the intended use case it may make sense to attach different rules to different graph elements, but in the use cases we consider here, rules would apply to the entire graph. Therefore, rules are only attached to the root node. It is up to the client feature (e.g. proxy-view) to look for and apply rules on a graph.

### Constructing Rules
A `SemanticFilterTag`, `TrueConnective` and `FalseConnective` are atomic rules. Rules can be constructed using connectives and other rules. The following logical connectives are defined:
- IdentityConnective
- NegationConnective
- AndConnective
- OrConnective
- IfThenConnective
- IfThenElseConnective

### Numeric Tags and Rules
A `SemanticFilterTag` can also have a number in addition to a string and there are special numerical connectives that take a `SemanticFilterTag` as an operand and evaluate to true or false according to the number saved in that tag. The following numeric connectives are defined:
- NumericEqualConnective
- NumericNotEqualConnective
- GreaterThanConnective
- GreaterEqualsConnective
- LessThanConnective
- LessEqualsConnective

### Numeric Connectives with Numeric Results
The following rules take numeric inputs and output a numeric value themselves. They can be used to construct more complex expressions such as "states" where the sum of "declarations" and "childCount" is larger than some value.
- NumericPlusConnective
- NumericMinusConnective
- NumericTimesConnective
- NumericDividesConnective

### Code Examples

#### Adding tags and rules on the server
In the following we declare some simple tags and a numeric tag.
```
/** Tag giving semantic meaning that the element is a state. */
public static final SemanticFilterTag STATE = new SemanticFilterTag("state");
/** Tag giving semantic meaning that the element is final. */
public static final SemanticFilterTag FINAL = new SemanticFilterTag("final");

/** Returns a tag giving semantic meaning how many declarations an element has. */
public static SemanticFilterTag DECLARATIONS(Double num) {
    return new SemanticFilterTag("numDeclarations", num);
}

/** Returns a tag giving semantic meaning how many declarations an element has without a value.
 * Used for constructing rules involving the tag.
 * /
public static SemanticFilterTag DECLARATIONS = new SemanticFilterTag("numDeclarations);
```
We can then assign these tags during the synthesis.
```
node.getProperty(KlighdProperties.SEMANTIC_FILTER_TAGS).add(SCChartsSemanticFilterTags.STATE)
...
node.getProperty(KlighdProperties.SEMANTIC_FILTER_TAGS).add(SCChartsSemanticFilterTags.DECLARATIONS(filteredDeclarations.size as double)) 
```
Next, we need some rules that we can use to filter elements on the client.in
```
/** Rule to exclude elements that are states. */
public static final SemanticFilterRule NO_STATES = new NegationConnective(SCChartsSemanticFilterTags.STATE, "Filter States");

/** Rule to only include elements that have at least 3 declarations. */
public static final SemanticFilterRule ONLY_AT_LEAST_3_DECLARATIONS = new OrConnective(
    new LessEqualsConnective(new NumericConstantConnective(3.0), SCChartsSemanticFilterTags.DECLARATIONS
    "Filter Elements With Less Than 3 Declarations");
```

Finally we can add the rules to the graph (here we add them to the root node) [xtend].
```
rootNode.setProperty(KlighdProperties.SEMANTIC_FILTER_RULES, #[NO_STATES, ONLY_AT_LEAST_3_DECLARATIONS])
```
#### Expression language for creating filter rules
In addition to the programmatic method of defining rules an expression language may be used. `SemanticFilterRuleParserUtil.parse(<ExpressionString>)` may be used to parse these expressions and obtain the corresponding `SemanticFilterRule`.

Expressions are built up analogously to the programmatic construction. Each expression is evaluated either to a boolean or numeric value. An atomic expression is either a constant (`true`, `false` or a string that can be parsed as Java double) or a tag variable. A tag variable consists of a string identifier (without whitespaces) and is preceded by `#` to denote a boolean value i.e. the tag is present or not or by a `$` to denote a numeric value. Whitespaces are used as separators between operators and expressions. The table below gives an overview over the available operators. Brackets (`(`,`)`) may additionally be used to override precedence.

| Operator |  Syntax  |  Input  | Output | Precedence |
|---|---|---|---|---|
| And | \<expr\> && \<expr\> | boolean | boolean | 4 |
| Or | \<expr\> \|\| \<expr\> | boolean | boolean | 3 |
| Not | ! \<expr\> | boolean | boolean | 6 |
| Addition | \<expr\> + \<expr\> | numeric | numeric | 9 |
| Subtraction | \<expr\> - \<expr\> | numeric | numeric | 9 |
| Multiplication | \<expr\> * \<expr\> | numeric | numeric | 10 |
| Division | \<expr\> / \<expr\> | numeric | numeric | 10 |
| GreaterEquals | \<expr\> >= \<expr\> | numeric | boolean | 8 |
| GreaterThan | \<expr\> > \<expr\> | numeric | boolean | 8 |
| LessEquals | \<expr\> <= \<expr\> | numeric | boolean | 8 |
| LessThan | \<expr\> < \<expr\> | numeric | boolean | 8 |
| Equals | \<expr\> = \<expr\> | numeric/boolean | boolean | 7 |
| NotEqual | \<expr\> != \<expr\> | numeric/boolean | boolean | 7 |

##### Valid example expressions
- `#initial || $regions >= 3` - keeps all elements that have the tag `initial` or have the tag `regions` with a value of 3 or higher.
- `$children + $importance > $weight` - keeps all elements where the sum of the `children` and `importance` tags is higher than the value of the `weight` tag

#### Evaluating rules on the client
How exactly a feature on the client uses these tags and rules is flexible. In general the rules should be retrieved from the graph and some decision must be made on how to choose a rule based on its name. Then rules can be applied on graph elements, which allows filtering of elements.

Getting filters from the root
```
import { Filter, getFilters } from "../../filtering/semantic-filtering-util";
...
filters: Filter[] = getFilters(rootNode)
```
Filter interface
```
export interface Filter {
    name?: string
    defaultValue?: boolean
    filterFun(el: SKGraphElement): boolean
}
```
Now using a list of graph elements we can use the ```filter``` function to apply this ```Filter``` to all graph elements and get a filtered list of graph elements.
