### PR TITLE
Replace deprecated WidgetProperties and simplify klighd.ui.printing.dialog

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/ActionsBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/ActionsBlock.java
@@ -28,8 +28,7 @@
 package de.cau.cs.kieler.klighd.ui.printing.dialog;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -80,29 +79,22 @@ final class ActionsBlock {
 
         printPreview.setText(KlighdUIPrintingMessages.PrintDialog_Button_PrintPreview + arrows);
         printPreview.setEnabled(previewEnabled);
-        printPreview.addSelectionListener(new SelectionAdapter() {
+        printPreview.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+            final PrintPreviewTray tray = printDialog.getTray();
 
-            /**
-             * {@inheritDoc}
-             */
-            @Override
-            public void widgetSelected(final SelectionEvent e) {
-                final PrintPreviewTray tray = printDialog.getTray();
+            if (tray != null) {
+                printDialog.closeTray();
+                printPreview.setText(
+                        KlighdUIPrintingMessages.PrintDialog_Button_PrintPreview + OPEN_ARROWS);
+                DiagramPrintOptions.setInitiallyShowPreview(false);
 
-                if (tray != null) {
-                    printDialog.closeTray();
-                    printPreview.setText(
-                            KlighdUIPrintingMessages.PrintDialog_Button_PrintPreview + OPEN_ARROWS);
-                    DiagramPrintOptions.setInitiallyShowPreview(false);
-
-                } else {
-                    printDialog.openPreview();
-                    printPreview.setText(
-                            KlighdUIPrintingMessages.PrintDialog_Button_PrintPreview + CLOSE_ARROWS);
-                    DiagramPrintOptions.setInitiallyShowPreview(true);
-                }
+            } else {
+                printDialog.openPreview();
+                printPreview.setText(
+                        KlighdUIPrintingMessages.PrintDialog_Button_PrintPreview + CLOSE_ARROWS);
+                DiagramPrintOptions.setInitiallyShowPreview(true);
             }
-        });
+        }));
 
         return printPreview;
     }

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/AlignmentBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/AlignmentBlock.java
@@ -25,9 +25,7 @@ import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
-import org.eclipse.swt.widgets.Listener;
 
 import de.cau.cs.kieler.klighd.ui.printing.KlighdUIPrintingMessages;
 import de.cau.cs.kieler.klighd.ui.printing.PrintOptions;
@@ -82,24 +80,21 @@ final class AlignmentBlock {
         final Realm realm = bindings.getValidationRealm();
 
         final IObservableValue<Object> centerHorValue = 
-                BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_CENTER_HORIZONTALLY)
+                BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_CENTER_HORIZONTALLY)
                     .observe(realm, options);
         ISWTObservableValue<Object> horObservation = WidgetProperties.selection().observe(centerHorizontally);
         bindings.bindValue(horObservation, centerHorValue);
 
-        final IObservableValue<Object> centerVerValue = BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_CENTER_VERTICALLY)
+        final IObservableValue<Object> centerVerValue = BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_CENTER_VERTICALLY)
                 .observe(realm, options);
         ISWTObservableValue<Object> vertObservation = WidgetProperties.selection().observe(centerVertically);
         bindings.bindValue(vertObservation, centerVerValue);
 
-        result.addListener(SWT.Dispose, new Listener() {
-
-            public void handleEvent(final Event event) {
-                // while the SWTObservableValues are disposed while disposing the corresponding widgets
-                //  the Beans-based ones should be disposed explicitly
-                centerHorValue.dispose();
-                centerVerValue.dispose();
-            }
+        result.addListener(SWT.Dispose, event -> {
+            // while the SWTObservableValues are disposed while disposing the corresponding widgets
+            //  the Beans-based ones should be disposed explicitly
+            centerHorValue.dispose();
+            centerVerValue.dispose();
         });
 
         return result;

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/AlignmentBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/AlignmentBlock.java
@@ -21,7 +21,7 @@ import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -82,12 +82,12 @@ final class AlignmentBlock {
         final IObservableValue<Object> centerHorValue = 
                 BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_CENTER_HORIZONTALLY)
                     .observe(realm, options);
-        ISWTObservableValue<Object> horObservation = WidgetProperties.selection().observe(centerHorizontally);
+        ISWTObservableValue<Object> horObservation = WidgetProperties.widgetSelection().observe(centerHorizontally);
         bindings.bindValue(horObservation, centerHorValue);
 
         final IObservableValue<Object> centerVerValue = BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_CENTER_VERTICALLY)
                 .observe(realm, options);
-        ISWTObservableValue<Object> vertObservation = WidgetProperties.selection().observe(centerVertically);
+        ISWTObservableValue<Object> vertObservation = WidgetProperties.widgetSelection().observe(centerVertically);
         bindings.bindValue(vertObservation, centerVerValue);
 
         result.addListener(SWT.Dispose, event -> {

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/CopiesBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/CopiesBlock.java
@@ -31,8 +31,6 @@ import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
-import org.eclipse.core.databinding.observable.value.IValueChangeListener;
-import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -41,10 +39,8 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Widget;
 
@@ -106,7 +102,7 @@ final class CopiesBlock {
         final Spinner copiesSpinner = DialogUtil.spinner(result, 1, Integer.MAX_VALUE);
 
         final IObservableValue<Object> copiesValue = 
-                BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_COPIES).observe(realm, options);
+                BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_COPIES).observe(realm, options);
         ISWTObservableValue<Object> copiesObservation = WidgetProperties.selection().observe(copiesSpinner);
         bindings.bindValue(copiesObservation, copiesValue);
 
@@ -123,34 +119,27 @@ final class CopiesBlock {
         collateImageLabel.setImage(collateCheck.getSelection() ? collateOnImage : collateOffImage);
 
         final IObservableValue<Object> collateValue =
-                BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_COLLATE).observe(realm, options);
+                BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_COLLATE).observe(realm, options);
         ISWTObservableValue<Object> collateObservation =  WidgetProperties.selection().observe((Widget) collateCheck);
         bindings.bindValue(collateObservation, collateValue);
 
-        collateValue.addValueChangeListener(new IValueChangeListener<Object>() {
-
-            public void handleValueChange(final ValueChangeEvent<? extends Object> event) {
-
-                // set image according to collate state
-                if (((Boolean) event.getObservableValue().getValue()).booleanValue()) {
-                    collateImageLabel.setImage(collateOnImage);
-                } else {
-                    collateImageLabel.setImage(collateOffImage);
-                }
+        collateValue.addValueChangeListener(event -> {
+            // set image according to collate state
+            if (((Boolean) event.getObservableValue().getValue()).booleanValue()) {
+                collateImageLabel.setImage(collateOnImage);
+            } else {
+                collateImageLabel.setImage(collateOffImage);
             }
         });
 
-        result.addListener(SWT.Dispose, new Listener() {
+        result.addListener(SWT.Dispose, event -> {
+            collateOnImage.dispose();
+            collateOffImage.dispose();
 
-            public void handleEvent(final Event event) {
-                collateOnImage.dispose();
-                collateOffImage.dispose();
-
-                // while the SWTObservableValues are disposed while disposing the corresponding widgets
-                //  the Beans-based ones should be disposed explicitly
-                copiesValue.dispose();
-                collateValue.dispose();
-            }
+            // while the SWTObservableValues are disposed while disposing the corresponding widgets
+            //  the Beans-based ones should be disposed explicitly
+            copiesValue.dispose();
+            collateValue.dispose();
         });
 
         if (Klighd.IS_MACOSX) {

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/CopiesBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/CopiesBlock.java
@@ -32,7 +32,7 @@ import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
@@ -42,7 +42,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Spinner;
-import org.eclipse.swt.widgets.Widget;
 
 import de.cau.cs.kieler.klighd.Klighd;
 import de.cau.cs.kieler.klighd.ui.KlighdUIPlugin;
@@ -103,7 +102,7 @@ final class CopiesBlock {
 
         final IObservableValue<Object> copiesValue = 
                 BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_COPIES).observe(realm, options);
-        ISWTObservableValue<Object> copiesObservation = WidgetProperties.selection().observe(copiesSpinner);
+        ISWTObservableValue<Object> copiesObservation = WidgetProperties.widgetSelection().observe(copiesSpinner);
         bindings.bindValue(copiesObservation, copiesValue);
 
         final Image collateOnImage = COLLATE_ON.createImage();
@@ -120,7 +119,7 @@ final class CopiesBlock {
 
         final IObservableValue<Object> collateValue =
                 BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_COLLATE).observe(realm, options);
-        ISWTObservableValue<Object> collateObservation =  WidgetProperties.selection().observe((Widget) collateCheck);
+        ISWTObservableValue<Object> collateObservation = WidgetProperties.widgetSelection().observe(collateCheck);
         bindings.bindValue(collateObservation, collateValue);
 
         collateValue.addValueChangeListener(event -> {

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/KlighdPrintDialog.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/KlighdPrintDialog.java
@@ -204,11 +204,7 @@ public class KlighdPrintDialog extends TrayDialog {
             // this asyncExec is employed in order to let the main dialog get build up properly;
             // for some reason its layout gets heavily corrupted if the preview is opened directly
             //  some good soul might investigate this some day...
-            parent.getDisplay().asyncExec(new Runnable() {
-                public void run() {
-                    openPreview();
-                }
-            });
+            parent.getDisplay().asyncExec(this::openPreview);
         }
 
         return result;

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/OrientationBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/OrientationBlock.java
@@ -22,7 +22,7 @@ import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.SelectObservableValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.printing.PrinterData;
 import org.eclipse.swt.widgets.Button;
@@ -83,9 +83,9 @@ final class OrientationBlock {
 
         final SelectObservableValue<Integer> orientationGroupValue = new SelectObservableValue<>(realm);
         
-        ISWTObservableValue<Boolean> observerPortrait = WidgetProperties.selection().observe(portraitRadio);
+        ISWTObservableValue<Boolean> observerPortrait = WidgetProperties.<Button, Boolean> widgetSelection().observe(portraitRadio);
         orientationGroupValue.addOption(PrinterData.PORTRAIT, observerPortrait);
-        ISWTObservableValue<Boolean> observeLandscape = WidgetProperties.selection().observe(landscapeRadio);
+        ISWTObservableValue<Boolean> observeLandscape = WidgetProperties.<Button, Boolean> widgetSelection().observe(landscapeRadio);
         orientationGroupValue.addOption(PrinterData.LANDSCAPE, observeLandscape);
 
         IObservableValue<Object> observeOrientation = BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_ORIENTATION)

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/OrientationBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/OrientationBlock.java
@@ -88,7 +88,7 @@ final class OrientationBlock {
         ISWTObservableValue<Boolean> observeLandscape = WidgetProperties.selection().observe(landscapeRadio);
         orientationGroupValue.addOption(PrinterData.LANDSCAPE, observeLandscape);
 
-        IObservableValue<Object> observeOrientation = BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_ORIENTATION)
+        IObservableValue<Object> observeOrientation = BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_ORIENTATION)
                 .observe(realm, options);
         bindings.bindValue(orientationGroupValue, observeOrientation);
 

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrintPreviewTray.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrintPreviewTray.java
@@ -27,7 +27,7 @@ import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.IValueChangeListener;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.dialogs.DialogTray;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrintPreviewTray.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrintPreviewTray.java
@@ -26,7 +26,6 @@ import org.eclipse.core.databinding.observable.Observables;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.core.databinding.observable.value.IValueChangeListener;
-import org.eclipse.core.databinding.observable.value.ValueChangeEvent;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.dialogs.DialogTray;
@@ -37,9 +36,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 
 import de.cau.cs.kieler.klighd.DiagramExportConfig;
 import de.cau.cs.kieler.klighd.ui.printing.DiagramPrintOptions;
@@ -104,65 +101,57 @@ public class PrintPreviewTray extends DialogTray {
 
         updateComposite();
 
-        final IValueChangeListener<Object> listener = new IValueChangeListener<Object>() {
-
-            public void handleValueChange(final ValueChangeEvent<? extends Object> event) {
-                updateComposite();
-            }
-        };
+        final IValueChangeListener<Object> listener = event -> updateComposite();
 
         ISWTObservableValue<Point> observedSize = WidgetProperties.size().observe(body);
         final IObservableValue<Point> delayedResize = Observables.observeDelayedValue(OBSERVABLE_DELAY, observedSize);
         delayedResize.addValueChangeListener(listener);
 
         IObservableValue<Object> observedData = 
-                BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_PRINTER_DATA)
+                BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_PRINTER_DATA)
                 .observe(realm, options);
         final IObservableValue<Object> delayedPrinterData = Observables.observeDelayedValue(OBSERVABLE_DELAY, observedData);
         delayedPrinterData.addValueChangeListener(listener);
 
-        IObservableValue<Object> observedScale = BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_SCALE_FACTOR)
+        IObservableValue<Object> observedScale = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_SCALE_FACTOR)
                 .observe(realm, options);
         final IObservableValue<Object> delayedScale = Observables.observeDelayedValue(OBSERVABLE_DELAY,observedScale);
         delayedScale.addValueChangeListener(listener);
 
-        IObservableValue<Object> observedPagesWide = BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_PAGES_WIDE)
+        IObservableValue<Object> observedPagesWide = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_PAGES_WIDE)
                 .observe(realm, options);
         final IObservableValue<Object> delayedPagesWide = Observables.observeDelayedValue(OBSERVABLE_DELAY,observedPagesWide);
         delayedPagesWide.addValueChangeListener(listener);
 
-        IObservableValue<Object> observedScaleTall = BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_PAGES_TALL)
+        IObservableValue<Object> observedScaleTall = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_PAGES_TALL)
                 .observe(realm, options);
         final IObservableValue<Object> delayedPagesTall = Observables.observeDelayedValue(OBSERVABLE_DELAY, observedScaleTall);
         delayedPagesTall.addValueChangeListener(listener);
 
-        IObservableValue<Object> observedHorCenter = BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_CENTER_HORIZONTALLY)
+        IObservableValue<Object> observedHorCenter = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_CENTER_HORIZONTALLY)
                 .observe(realm, options);
         final IObservableValue<Object> delayedHorCentered = Observables.observeDelayedValue(OBSERVABLE_DELAY, observedHorCenter);
         delayedHorCentered.addValueChangeListener(listener);
 
-        IObservableValue<Object> observedVertCenter = BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_CENTER_VERTICALLY)
+        IObservableValue<Object> observedVertCenter = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_CENTER_VERTICALLY)
                 .observe(realm, options);
         final IObservableValue<Object> delayedVerCentered = Observables.observeDelayedValue(OBSERVABLE_DELAY, observedVertCenter);
         delayedVerCentered.addValueChangeListener(listener);
         
-        IObservableValue<Object> observedOrientation = BeanProperties.value(options.getClass().asSubclass(DiagramPrintOptions.class), PrintOptions.PROPERTY_ORIENTATION)
+        IObservableValue<Object> observedOrientation = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_ORIENTATION)
                 .observe(realm, options);
         final IObservableValue<Object> delayedOrientation = Observables.observeDelayedValue(OBSERVABLE_DELAY, observedOrientation);
         delayedOrientation.addValueChangeListener(listener);
 
-        body.addListener(SWT.Dispose, new Listener() {
-
-            public void handleEvent(final Event event) {
-                delayedResize.dispose();
-                delayedPrinterData.dispose();
-                delayedScale.dispose();
-                delayedPagesWide.dispose();
-                delayedPagesTall.dispose();
-                delayedHorCentered.dispose();
-                delayedVerCentered.dispose();
-                delayedOrientation.dispose();
-            }
+        body.addListener(SWT.Dispose, event -> {
+            delayedResize.dispose();
+            delayedPrinterData.dispose();
+            delayedScale.dispose();
+            delayedPagesWide.dispose();
+            delayedPagesTall.dispose();
+            delayedHorCentered.dispose();
+            delayedVerCentered.dispose();
+            delayedOrientation.dispose();
         });
 
         return body;
@@ -253,12 +242,7 @@ public class PrintPreviewTray extends DialogTray {
 
                     final Label l = new Label(composite, SWT.NULL);
                     l.setImage(pageImg);
-                    l.addListener(SWT.Dispose, new Listener() {
-
-                        public void handleEvent(final Event event) {
-                            pageImg.dispose();
-                        }
-                    });
+                    l.addListener(SWT.Dispose, event -> pageImg.dispose());
                 }
             }
         }

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrinterBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrinterBlock.java
@@ -32,7 +32,7 @@ import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.ComputedValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.printing.PrintDialog;

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrinterBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/PrinterBlock.java
@@ -34,16 +34,13 @@ import org.eclipse.core.databinding.observable.value.ComputedValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.printing.PrintDialog;
 import org.eclipse.swt.printing.PrinterData;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 
 import de.cau.cs.kieler.klighd.ui.printing.KlighdUIPrintingMessages;
 import de.cau.cs.kieler.klighd.ui.printing.PrintOptions;
@@ -105,7 +102,7 @@ final class PrinterBlock {
             protected String calculate() {
                 final PrinterData data = 
                         (PrinterData) BeanProperties
-                        .value( options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_PRINTER_DATA)
+                        .value( PrintOptions.class, PrintOptions.PROPERTY_PRINTER_DATA)
                         .observe(realm, options)
                         .getValue();
                 if (data.printToFile) {
@@ -123,31 +120,22 @@ final class PrinterBlock {
                 DialogUtil.button(result, KlighdUIPrintingMessages.PrintDialog_PrinterSettings);
         propertiesButton.setEnabled(true);
 
-        propertiesButton.addSelectionListener(new SelectionAdapter() {
+        propertiesButton.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+            // Open the system's native print dialog to gather printer specific settings.
+            // If no valid setting are returned (e.g. the user cancels the dialog),
+            // nothing is changed.
+            final PrintDialog systemPrintDialog = printDialog.getNativePrintDialog();
+            systemPrintDialog.setPrinterData(options.getPrinterData());
 
-            @Override
-            public void widgetSelected(final SelectionEvent e) {
-                // Open the system's native print dialog to gather printer specific settings.
-                // If no valid setting are returned (e.g. the user cancels the dialog),
-                //  nothing is changed.
-                final PrintDialog systemPrintDialog = printDialog.getNativePrintDialog();
-                systemPrintDialog.setPrinterData(options.getPrinterData());
-
-                final PrinterData data = systemPrintDialog.open();
-                if (data != null) {
-                    options.setPrinterData(data);
-                }
+            final PrinterData data = systemPrintDialog.open();
+            if (data != null) {
+                options.setPrinterData(data);
             }
-        });
+        }));
 
-        result.addListener(SWT.Dispose, new Listener() {
-
-            public void handleEvent(final Event event) {
-                // while the SWTObservableValues are disposed while disposing the corresponding widgets
-                //  the ComputedValue should be disposed explicitly
-                computedValue.dispose();
-            }
-        });
+        // while the SWTObservableValues are disposed while disposing the corresponding widgets
+        // the ComputedValue should be disposed explicitly
+        result.addListener(SWT.Dispose, event -> computedValue.dispose());
 
         return result;
     }

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/RangeBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/RangeBlock.java
@@ -33,7 +33,7 @@ import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.ComputedValue;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -92,7 +92,7 @@ final class RangeBlock {
         
         final IObservableValue<Object> allValue =
                 BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_ALL_PAGES).observe(realm, options);
-        ISWTObservableValue<Object> observedAllPages = WidgetProperties.selection().observe(allRadio); 
+        ISWTObservableValue<Object> observedAllPages = WidgetProperties.widgetSelection().observe(allRadio); 
         bindings.bindValue(observedAllPages, allValue);
 
         // radio button for defining a print range
@@ -118,7 +118,7 @@ final class RangeBlock {
                 return ((Boolean) allValue.getValue()).booleanValue() ? Boolean.FALSE : Boolean.TRUE;
             }
         };
-        ISWTObservableValue<Object> selection = WidgetProperties.selection().observe(rangeRadio);
+        ISWTObservableValue<Object> selection = WidgetProperties.widgetSelection().observe(rangeRadio);
         bindings.bindValue(selection, rangeValue);
 
         // range from (label & textfield)

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/RangeBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/RangeBlock.java
@@ -91,7 +91,7 @@ final class RangeBlock {
         DialogUtil.layoutSpanHorizontal(allRadio, columns);
         
         final IObservableValue<Object> allValue =
-                BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_ALL_PAGES).observe(realm, options);
+                BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_ALL_PAGES).observe(realm, options);
         ISWTObservableValue<Object> observedAllPages = WidgetProperties.selection().observe(allRadio); 
         bindings.bindValue(observedAllPages, allValue);
 
@@ -128,7 +128,7 @@ final class RangeBlock {
         final Text textFrom = DialogUtil.text(result, textWidth);
 
         final IObservableValue<Object> rangeFrom = 
-                BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_RANGE_FROM).observe(realm, options);
+                BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_RANGE_FROM).observe(realm, options);
         ISWTObservableValue<String> observedModifiedTextFrom = WidgetProperties.text(SWT.Modify).observe(textFrom); 
         bindings.bindValue(observedModifiedTextFrom, rangeFrom);
         ISWTObservableValue<Boolean> observedEnabledFrom = WidgetProperties.enabled().observe(textFrom);
@@ -141,7 +141,7 @@ final class RangeBlock {
         final Text textTo = DialogUtil.text(result, textWidth);
 
         final IObservableValue<Object> rangeTo =
-                BeanProperties.value(options.getClass().asSubclass(PrintOptions.class), PrintOptions.PROPERTY_RANGE_TO).observe(realm, options);
+                BeanProperties.value(PrintOptions.class, PrintOptions.PROPERTY_RANGE_TO).observe(realm, options);
         
         ISWTObservableValue<String> observedModifyTextTo = WidgetProperties.text(SWT.Modify).observe(textTo);
         bindings.bindValue(observedModifyTextTo, rangeTo);

--- a/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/ScalingBlock.java
+++ b/plugins/de.cau.cs.kieler.klighd.ui/src/de/cau/cs/kieler/klighd/ui/printing/dialog/ScalingBlock.java
@@ -34,7 +34,7 @@ import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.value.IObservableValue;
 import org.eclipse.jface.databinding.swt.ISWTObservableValue;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridLayout;
@@ -172,17 +172,17 @@ final class ScalingBlock {
 
             final IObservableValue<Object> scalePercent = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_SCALE_PERCENT)
                     .observe(realm, dOptions);
-            ISWTObservableValue<Object> observerScaleSpinner = WidgetProperties.selection().observe(scaleSpinner);
+            ISWTObservableValue<Object> observerScaleSpinner = WidgetProperties.widgetSelection().observe(scaleSpinner);
             bindings.bindValue(observerScaleSpinner, scalePercent);
 
             final IObservableValue<Object> pagesWide = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_PAGES_WIDE)
                     .observe(realm, dOptions);
-            ISWTObservableValue<Object> observerWideSpinner = WidgetProperties.selection().observe(spinnerWide);
+            ISWTObservableValue<Object> observerWideSpinner = WidgetProperties.widgetSelection().observe(spinnerWide);
             bindings.bindValue(observerWideSpinner, pagesWide);
 
             final IObservableValue<Object> pagesTall = BeanProperties.value(DiagramPrintOptions.class, PrintOptions.PROPERTY_PAGES_TALL)
                     .observe(realm, dOptions);
-            ISWTObservableValue<Object> observerTallSpinner = WidgetProperties.selection().observe(spinnerTall);
+            ISWTObservableValue<Object> observerTallSpinner = WidgetProperties.widgetSelection().observe(spinnerTall);
             bindings.bindValue(observerTallSpinner, pagesTall);
 
             result.addListener(SWT.Dispose, event -> {


### PR DESCRIPTION
This PR is split in two commits and has the goal to first simplify the classes in `de.cau.cs.kieler.klighd.ui.printing.dialog` and to replace the deprecated class `org.eclipse.jface.databinding.swt.WidgetProperties`, which is eventually removed in the Eclipse 2022-12 release.
The first commit addresses the first topic and the second one the second.

Please let me know if you prefer more fine grained PRs.

Edit: The deletion is done in https://github.com/eclipse-platform/eclipse.platform.ui/commit/c44f8d77f42cbcc17a0da3daabbb16bcd8745a86