### PR TITLE
klighd: fixed inset calculation.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/microlayout/PlacementUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/microlayout/PlacementUtil.java
@@ -1570,6 +1570,9 @@ public final class PlacementUtil {
             if (currentRendering instanceof KContainerRendering) {
                 currentParent = (KContainerRendering) currentRendering;
                 currentBounds = bounds;
+                // Reset current position to avoid adding top/left insets multiple times.
+                currentBounds.x = 0;
+                currentBounds.y = 0;
             }
         }
 


### PR DESCRIPTION
Previously insets were calculated wrong by offsetting all insets too much when renderings were inside renderigns with offsets. For the server this is an invisible fix, as all Piccolo-related rendering code do not directly use these insets, LSP rendering however directly use the insets for Sprotty, which are now fixed.