### PR TITLE
update build

### DIFF
--- a/build/de.cau.cs.kieler.klighd.repository/category.xml
+++ b/build/de.cau.cs.kieler.klighd.repository/category.xml
@@ -63,11 +63,11 @@
    <bundle id="de.cau.cs.kieler.klighd.lsp" version="2.2.1.qualifier"/>
    <bundle id="de.cau.cs.kieler.klighd.lsp.source" version="2.2.1.qualifier"/>
 
-   <repository-reference location="https://download.eclipse.org/releases/2021-06/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/releases/2022-09/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/modeling/mdt/uml2/updates/5.4/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/elk/updates/releases/0.8.1/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.28.0/" enabled="true" />
    <repository-reference location="https://xtext.github.io/download/updates/releases/2.1.1/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository/" enabled="true" />
    <repository-reference location="https://rtsys.informatik.uni-kiel.de/~kieler/updatesite/sprotty/0.9.0/" enabled="true" />
 </site>

--- a/build/de.cau.cs.kieler.klighd.repository/pom.xml
+++ b/build/de.cau.cs.kieler.klighd.repository/pom.xml
@@ -41,7 +41,7 @@
       <plugin>
         <groupId>org.jboss.tools.tycho-plugins</groupId>
         <artifactId>repository-utils</artifactId>
-        <version>2.5.0</version>
+        <version>2.7.5</version>
         <executions>
           <execution>
             <id>generate-facade</id>
@@ -52,17 +52,17 @@
             <configuration>
               <associateSites>
                 <!-- Eclipse -->
-                <associateSite>https://download.eclipse.org/releases/2021-06/</associateSite>
+                <associateSite>https://download.eclipse.org/releases/2022-09/</associateSite>
                 <!-- UML2 Tools (Meta Model Implemenetation, ...) -->
                 <associateSite>https://download.eclipse.org/modeling/mdt/uml2/updates/5.4/</associateSite>
                 <!-- Eclipse Layout Kernel -->
                 <!-- associateSite>http://build.eclipse.org/modeling/elk/updates/nightly/</associateSite -->
                 <associateSite>https://download.eclipse.org/elk/updates/releases/0.8.1/</associateSite>>
                 <!-- Xtext -->
-                <associateSite>https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/</associateSite>>
+                <associateSite>https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.28.0/</associateSite>>
                 <associateSite>https://xtext.github.io/download/updates/releases/2.1.1/</associateSite>>
                 <!-- Eclipse Orbit for Google Guave, Apache Batik, ... -->
-                <associateSite>https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/</associateSite>
+                <associateSite>https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository/</associateSite>
                 <!-- Sprotty ... -->
                 <associateSite>https://rtsys.informatik.uni-kiel.de/~kieler/updatesite/sprotty/0.9.0/</associateSite>
               </associateSites>

--- a/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-elkNightly.target
+++ b/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-elkNightly.target
@@ -8,7 +8,7 @@
       <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
       <unit id="org.apache.batik.svggen" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-06/"/>
+      <repository location="https://download.eclipse.org/releases/2022-09/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.uml2.uml.feature.group" version="0.0.0"/>
@@ -25,7 +25,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.28.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
@@ -36,7 +36,7 @@
       <unit id="com.google.inject" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
       <unit id="org.hamcrest.library" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.sprotty" version="0.0.0"/>

--- a/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-piccolo-elkNightly.target
+++ b/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-piccolo-elkNightly.target
@@ -8,7 +8,7 @@
       <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
       <unit id="org.apache.batik.svggen" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-06/"/>
+      <repository location="https://download.eclipse.org/releases/2022-09/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.uml2.uml.feature.group" version="0.0.0"/>
@@ -25,7 +25,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.28.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
@@ -40,7 +40,7 @@
       <unit id="com.google.inject" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
       <unit id="org.hamcrest.library" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.sprotty" version="0.0.0"/>

--- a/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-piccolo.target
+++ b/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform-piccolo.target
@@ -8,7 +8,7 @@
       <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
       <unit id="org.apache.batik.svggen" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-06/"/>
+      <repository location="https://download.eclipse.org/releases/2022-09/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.uml2.uml.feature.group" version="0.0.0"/>
@@ -25,7 +25,7 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.28.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
@@ -40,7 +40,7 @@
       <unit id="com.google.inject" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
       <unit id="org.hamcrest.library" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.sprotty" version="0.0.0"/>

--- a/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform.target
+++ b/build/de.cau.cs.kieler.klighd.targetplatform/de.cau.cs.kieler.klighd.targetplatform.target
@@ -8,7 +8,7 @@
       <unit id="org.eclipse.emf.ecore.xcore.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
       <unit id="org.apache.batik.svggen" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/releases/2021-06/"/>
+      <repository location="https://download.eclipse.org/releases/2022-09/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.uml2.uml.feature.group" version="0.0.0"/>
@@ -25,18 +25,18 @@
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
+      <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.28.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="de.itemis.xtext.antlr.sdk.feature.group" version="2.1.1.v201405091103"/>
       <repository location="https://xtext.github.io/download/updates/releases/2.1.1/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="javax.xml.bind" version="0.0.0"/>
+      <unit id="jakarta.servlet" version="0.0.0"/>
       <unit id="com.google.inject" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
       <unit id="org.hamcrest.library" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210223232630/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.sprotty" version="0.0.0"/>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 
   <!-- Define a few properties used throughout all build profiles. -->
   <properties>
-    <tycho-version>2.5.0</tycho-version>
-    <xtext-version>2.25.0</xtext-version>
+    <tycho-version>2.7.3</tycho-version>
+    <xtext-version>2.28.0</xtext-version>
     <elk-version>0.8.1</elk-version>
 
     <!-- chsch: copied from https://eclipse.googlesource.com/recommenders/org.eclipse.recommenders/+/3dae4575d3370da2da25a1cbce3dfcff198f0611/features/pom.xml -->


### PR DESCRIPTION
Tycho started to cause problems locally in the `.m2` folder with projects using Tycho 2.7 and 2.5, updating fixes this issue (only on local computers with shared `.m2` folders).
Updated other build versions and target platform to somewhat newer versions to conform to newer releases. The specific chosen release corresponds to the same current release dependencies in kieler/semantics.