### PR TITLE
Add property to automatically set minimal paddings for rounded rectangles

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
@@ -384,13 +384,15 @@ public class KlighdDiagramLayoutConnector implements IDiagramLayoutConnector {
         if (node.getProperty(KlighdProperties.ROUNDED_RECTANGLE_AUTOPADDING) != null) {
             KVector radii = node.getProperty(KlighdProperties.ROUNDED_RECTANGLE_AUTOPADDING);
             double padding = 0;
+            // threshold to check for almost zero-ness
+            double EPSILON = 0.00001;
             // x and y cannot be zero, if one of the two is zero use the larger value
-            if (radii.x < 0.00001 && radii.y >= 0.00001) {
-                radii.x = 0.00001;
-            } else if (radii.x >= 0.00001 && radii.y < 0.00001) {
-                radii.y = 0.00001;
+            if (radii.x < EPSILON && radii.y >= EPSILON) {
+                radii.x = EPSILON;
+            } else if (radii.x >= EPSILON && radii.y < EPSILON) {
+                radii.y = EPSILON;
             }
-            if (!(radii.x < 0.00001 && radii.y < 0.00001)) {
+            if (!(radii.x < EPSILON && radii.y < EPSILON)) {
                 // computes a padding x such that the corners of the inner rectangle fit exactly within the rounded rectangle
                 double numerator = radii.x * radii.y * (-Math.sqrt(2) * Math.sqrt(radii.x * radii.y) + radii.x + radii.y);
                 double denominator = radii.x * radii.x + radii.y * radii.y;

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
@@ -22,6 +22,7 @@ import java.util.ListIterator;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import org.eclipse.elk.core.math.ElkPadding;
 import org.eclipse.elk.core.math.KVector;
 import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.core.service.IDiagramLayoutConnector;
@@ -377,9 +378,26 @@ public class KlighdDiagramLayoutConnector implements IDiagramLayoutConnector {
 
         // KLighD is somewhat mean and doesn't care about existing insets
         node.setInsets(insets);
-        node.getProperty(CoreOptions.PADDING);
         // The Insets are used in {@link KlighdLayoutConfigurationStore} to retrieve the padding
         // of the node
+        
+        if (node.getProperty(KlighdProperties.ROUNDED_RECTANGLE_AUTOPADDING) != null) {
+            KVector radii = node.getProperty(KlighdProperties.ROUNDED_RECTANGLE_AUTOPADDING);
+            double padding = 0;
+            // x and y cannot be zero, if one of the two is zero use the larger value
+            if (radii.x < 0.00001 && radii.y >= 0.00001) {
+                radii.x = 0.00001;
+            } else if (radii.x >= 0.00001 && radii.y < 0.00001) {
+                radii.y = 0.00001;
+            }
+            if (!(radii.x < 0.00001 && radii.y < 0.00001)) {
+                // computes a padding x such that the corners of the inner rectangle fit exactly within the rounded rectangle
+                double numerator = radii.x * radii.y * (-Math.sqrt(2) * Math.sqrt(radii.x * radii.y) + radii.x + radii.y);
+                double denominator = radii.x * radii.x + radii.y * radii.y;
+                padding = numerator / denominator;
+            }
+            node.setProperty(CoreOptions.PADDING, new ElkPadding(padding));
+        }
 
         layoutParent.getChildren().add(layoutNode);
         mapping.getGraphMap().put(layoutNode, node);

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -378,7 +378,9 @@ public final class KlighdProperties {
     
     /**
      * Automatically computes the padding required to fit the content of a node within the bounds of a 
-     * rounded rectangle. The x and y corner radii are specified as x and y of a KVector.
+     * rounded rectangle. The x and y corner radii are specified as x and y of a KVector. If this property
+     * is set, the ElkPadding set on the graph will be overridden internally. This property should only be 
+     * used if no padding is manually set on the graph element.
      */
     public static final IProperty<KVector> ROUNDED_RECTANGLE_AUTOPADDING = 
             new Property<KVector>("klighd.roundedRectangle.autopadding", null);

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -375,4 +375,11 @@ public final class KlighdProperties {
      */
     public static final IProperty<Boolean> IS_NODE_TITLE =
             new Property<Boolean>("klighd.isNodeTitle", false);
+    
+    /**
+     * Automatically computes the padding required to fit the content of a node within the bounds of a 
+     * rounded rectangle. The x and y corner radii are specified as x and y of a KVector.
+     */
+    public static final IProperty<KVector> ROUNDED_RECTANGLE_AUTOPADDING = 
+            new Property<KVector>("klighd.roundedRectangle.autopadding", null);
 }


### PR DESCRIPTION
This property automatically creates a padding so that a node's content will fit into the bounds of a rounded rectangle. Can be used when using rounded rectangle renderings to automatically create the required minimal padding.