### PR TITLE
build with Java17

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 17
         distribution: adopt
     - name: Cache Maven packages
       uses: actions/cache@v2


### PR DESCRIPTION
Recently the KLighD build broke down due to Maven dependencies of some Eclipse Plugins now requiring Java17. Eclipse did not up the major versions of their bundles, thus causing newer builds to pull bundles from newer Eclipse releases requiring Java17 and therefore breaking the build process. This fixes the problem by using Java17 in the build process, making the Maven dependencies happy again, while not altering the source/target compatibility of the bundles themselves (mostly still capped to Java 1.8/Java 11 via BREEs in the Manifest files).