### PR TITLE
fix handling of edges by incremental update

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.incremental/src/de/cau/cs/kieler/klighd/incremental/diff/KComparison.java
+++ b/plugins/de.cau.cs.kieler.klighd.incremental/src/de/cau/cs/kieler/klighd/incremental/diff/KComparison.java
@@ -38,6 +38,7 @@ public class KComparison {
     private UIDAdapter baseAdapter;
     private UIDAdapter newAdapter;
     private MapDifference<String, KNode> nodeDifference;
+    private MapDifference<String, KEdge> edgeDifference;
 
     /**
      * Create new comparison.
@@ -51,6 +52,7 @@ public class KComparison {
         this.baseAdapter = baseAdapter;
         this.newAdapter = newAdapter;
         nodeDifference = Maps.difference(baseAdapter.getNodeMap(), newAdapter.getNodeMap());
+        edgeDifference = Maps.difference(baseAdapter.getEdgeMap(), newAdapter.getEdgeMap());
     }
 
     /**
@@ -184,6 +186,33 @@ public class KComparison {
      */
     public Collection<ValueDifference<KNode>> getMatchedNodes() {
         return nodeDifference.entriesDiffering().values();
+    }
+    
+    /**
+     * Get newly added edges.
+     * 
+     * @return the newly added edges.
+     */
+    public Collection<KEdge> getAddedEdges() {
+        return edgeDifference.entriesOnlyOnRight().values();
+    }
+
+    /**
+     * Get removed edges.
+     * 
+     * @return removed edges.
+     */
+    public Collection<KEdge> getRemovedEdges() {
+        return edgeDifference.entriesOnlyOnLeft().values();
+    }
+
+    /**
+     * Get matched edges, that are present in both models.
+     * 
+     * @return pairs of matched edges.
+     */
+    public Collection<ValueDifference<KEdge>> getMatchedEdges() {
+        return edgeDifference.entriesDiffering().values();
     }
 
 }

--- a/plugins/de.cau.cs.kieler.klighd.incremental/src/de/cau/cs/kieler/klighd/incremental/merge/KGraphMerger.java
+++ b/plugins/de.cau.cs.kieler.klighd.incremental/src/de/cau/cs/kieler/klighd/incremental/merge/KGraphMerger.java
@@ -137,7 +137,6 @@ public class KGraphMerger {
     private void handleMatchedEdges() {
         Set<KNode> nodesWithMatchedEdges = new HashSet<>();
         for (ValueDifference<KEdge> diff : comparison.getMatchedEdges()) {
-            nodesWithMatchedEdges.add(diff.leftValue().getSource());
             nodesWithMatchedEdges.add(diff.rightValue().getSource());
         }
         nodesWithMatchedEdges.forEach(
@@ -232,6 +231,10 @@ public class KGraphMerger {
                 int oldPosition = node.getParent().getChildren().indexOf(node);
                 KNode copiedNode = EcoreUtil.copy(node);
                 baseParent.getChildren().add(oldPosition, copiedNode);
+                // FIXME: if the added node also has a new edge, the target of that will not be set up yet and cause a 
+                // dangling reference here, possibly breaking further equality checks depending on correct IDs.
+                // One occurring issue: target port of new edge will have a wrong ID with the dangle string and can
+                // therefore not be found in the base model, causing the port to not be connected.
                 comparison.getBaseAdapter().generateIDs(copiedNode);
             }
         }

--- a/plugins/de.cau.cs.kieler.klighd.incremental/src/de/cau/cs/kieler/klighd/incremental/util/UIDAdapters.java
+++ b/plugins/de.cau.cs.kieler.klighd.incremental/src/de/cau/cs/kieler/klighd/incremental/util/UIDAdapters.java
@@ -58,7 +58,7 @@ public final class UIDAdapters {
         UIDAdapter newAdapter = new UIDAdapter();
         node.eAdapters().add(newAdapter);
         adapters.put(node, new WeakReference<UIDAdapter>(newAdapter));
-        newAdapter.generateIDs(node);
+        newAdapter.generateIDs(node, false, 0);
         return newAdapter;
     }
 

--- a/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/IncrementalUpdateTest.java
+++ b/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/IncrementalUpdateTest.java
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2020 by
+ * Copyright 2020-2023 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -648,6 +648,8 @@ public class IncrementalUpdateTest {
         EObject baseNewEdge = viewContext.getTargetElements(newEdgeSource).stream().findFirst().orElse(null);
         Assert.assertNotNull(baseNewEdge);
         Assert.assertTrue(baseNewEdge instanceof KEdge);
+        // Assert the new edge also connects to the new port correctly.
+        Assert.assertSame(baseNewPort, ((KEdge) baseNewEdge).getTargetPort());
         
         
         // Assert that the new node is in the same positions in the updated base graph as it is in the new graph.


### PR DESCRIPTION
Previously incremental update could run into an issue, where edges were not correctly connected to their target if said target was new. In that case the edge would sometimes be handled before the target resulting in edges connecting to wrong things. This fixes the problem by handling edges only after everything else has been updated.

To reproduce the original issue you can use the below minimal example SCChart and toggle the option induced dataflow: all on and off. The diagram is only drawn correctly after triggering a new synthesis.

```
scchart ports {
    region R:
    input bool A
    initial state s
    if A go to s
}
```
