### PR TITLE
Fixed build/Eclipse handling

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/RenderingPreparer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/RenderingPreparer.xtend
@@ -466,7 +466,7 @@ final class RenderingPreparer {
     static val StyleModificationContext singletonModContext = new StyleModificationContext();
     
     /**
-     * @see de.cau.cs.kieler.klighd.piccolo.internal.controller.AbstractKGERenderingController#processModifiableStyles
+     * See {@code de.cau.cs.kieler.klighd.piccolo.internal.controller.AbstractKGERenderingController#processModifiableStyles}
      */
     private static def void processModifiableStyles(KRendering rendering, KGraphElement parent) {
         val styles = if (rendering instanceof KRenderingRef)

--- a/plugins/de.cau.cs.kieler.klighd.piccolo.draw2d/src/de/cau/cs/kieler/klighd/piccolo/draw2d/Draw2DConnectionNode.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo.draw2d/src/de/cau/cs/kieler/klighd/piccolo/draw2d/Draw2DConnectionNode.java
@@ -79,7 +79,7 @@ public class Draw2DConnectionNode extends KCustomConnectionFigureNode {
             public void setPoints(final PointList pts) {
                 @SuppressWarnings("unchecked")
                 final
-                List<IFigure> children = this.getChildren();
+                List<IFigure> children = (List<IFigure>) this.getChildren();
                 for (final Connection child : Iterables.filter(children, Connection.class)) {
                     child.setPoints(pts);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -535,6 +535,77 @@
             </dependency>
           </dependencies>
         </plugin -->
+
+        <!-- Configure Eclipse m2e to ignore certain plugin goals when integrating Maven build
+          settings into Eclipse. -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-compiler-plugin</artifactId>
+                    <versionRange>${tycho-version}</versionRange>
+                    <goals>
+                      <goal>compile</goal>
+                      <goal>testCompile</goal>
+                      <goal>validate-classpath</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore/>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-packaging-plugin</artifactId>
+                    <versionRange>${tycho-version}</versionRange>
+                    <goals>
+                      <goal>build-qualifier</goal>
+                      <goal>build-qualifier-aggregator</goal>
+                      <goal>validate-id</goal>
+                      <goal>validate-version</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore/>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <versionRange>[3.0.0,)</versionRange>
+                    <goals>
+                      <goal>clean</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore/>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>target-platform-configuration</artifactId>
+                    <versionRange>[2.7.3,)</versionRange>
+                    <goals>
+                      <goal>target-platform</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Fixes the build when using newer Java versions. Fixes an issue arising when building the Maven+Plugin modules in Eclipse so that the m2e Tycho and Eclipse builders don't interfere.