### PR TITLE
Deprecated and replace the miss-spelled MODEL_ELEMEMT internal property 

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/interactive/layered/LayeredInteractiveLanguageServerExtension.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/interactive/layered/LayeredInteractiveLanguageServerExtension.xtend
@@ -239,7 +239,7 @@ class LayeredInteractiveLanguageServerExtension implements ILanguageServerExtens
         for (entry : changedNodes.keySet) {
             // set Property of corresponding elkNode 
             val kNode = entry.KNode
-            val elkNode = kNode.getProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+            val elkNode = kNode.getProperty(KlighdInternalProperties.MODEL_ELEMENT)
             
             if (elkNode instanceof ElkNode) {
                 val value = changedNodes.get(entry)
@@ -251,7 +251,7 @@ class LayeredInteractiveLanguageServerExtension implements ILanguageServerExtens
             }
         }
 
-        val elkNode = changedNodes.keySet().head.KNode.getProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+        val elkNode = changedNodes.keySet().head.KNode.getProperty(KlighdInternalProperties.MODEL_ELEMENT)
         if (elkNode instanceof ElkNode && changed) {
             val Map<String, List<TextEdit>> changes = newHashMap
             

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/interactive/rectpacking/RectpackingInteractiveLanguageServerExtension.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/interactive/rectpacking/RectpackingInteractiveLanguageServerExtension.xtend
@@ -165,7 +165,7 @@ class RectpackingInteractiveLanguageServerExtension implements ILanguageServerEx
         resource.save(outputStream, emptyMap)
         val codeBefore = outputStream.toString
         
-        val elkNode = kNode.getProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+        val elkNode = kNode.getProperty(KlighdInternalProperties.MODEL_ELEMENT)
         if (elkNode instanceof ElkNode) {
             val Map<String, List<TextEdit>> changes = newHashMap
             elkNode.setProperty(RectPackingOptions.ASPECT_RATIO, constraint.aspectRatio)
@@ -199,12 +199,12 @@ class RectpackingInteractiveLanguageServerExtension implements ILanguageServerEx
         val codeBefore = outputStream.toString
         
         for (node : changedNodes) {
-            val elkNode = node.getProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+            val elkNode = node.getProperty(KlighdInternalProperties.MODEL_ELEMENT)
             if (elkNode instanceof ElkNode) {
                 InteractiveUtil.copyAllConstraints(elkNode, node)
             }
         }
-        val elkNode = changedNodes.get(0).getProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+        val elkNode = changedNodes.get(0).getProperty(KlighdInternalProperties.MODEL_ELEMENT)
         if (elkNode instanceof ElkNode) {
             val Map<String, List<TextEdit>> changes = newHashMap
             

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/LazyTraceProvider.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/LazyTraceProvider.xtend
@@ -77,7 +77,7 @@ class LazyTraceProvider extends XtextTraceProvider {
     /**
      * Generates a trace for the {@code kElement}'s source EObject on the {@code sElement}. 
      * The kElement must be synthesized by a KLighD synthesis before and must have its source EObject stored in the 
-     * {@link KlighdInternalProperties#MODEL_ELEMEMT} property.
+     * {@link KlighdInternalProperties#MODEL_ELEMENT} property.
      * 
      * @param sElement The SModelElement that needs a trace to its model element.
      * @param kElement The KGraphElement that was generated from some model element.
@@ -86,7 +86,7 @@ class LazyTraceProvider extends XtextTraceProvider {
         // The real model element that can be traced is the EObject that got synthesized in the
         // {@link KGraphDiagramGenerator#translateModel} function. That model element has to be stored in the properties
         // during the synthesis. Otherwise the tracing will not work.
-        val modelElement = kElement.properties.get(KlighdInternalProperties.MODEL_ELEMEMT)
+        val modelElement = kElement.properties.get(KlighdInternalProperties.MODEL_ELEMENT)
         if (modelElement instanceof EObject) {
             if (modelElement.eResource instanceof XtextResource) {
                 trace(sElement, modelElement)

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdSetup.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/KlighdSetup.java
@@ -33,7 +33,7 @@ public class KlighdSetup implements IKlighdStartupHook {
     @Override
     public void execute() {
         KlighdDataManager.getInstance()
-            .registerBlacklistedProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+            .registerBlacklistedProperty(KlighdInternalProperties.MODEL_ELEMENT)
             .registerBlacklistedProperty(LabelManagementOptions.LABEL_MANAGER)
             .registerBlacklistedProperty(GridPlacementUtil.ESTIMATED_GRID_DATA)
             .registerBlacklistedProperty(GridPlacementUtil.CHILD_AREA_POSITION);

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/ViewContext.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/ViewContext.java
@@ -654,10 +654,10 @@ public class ViewContext extends MapPropertyHolder {
      */
     public void associateSourceTargetPair(final Object source, final EObject target) {
         if (KGraphPackage.eINSTANCE.getKGraphData().isInstance(target)) {
-            ((KGraphData) target).setProperty(KlighdInternalProperties.MODEL_ELEMEMT, source);
+            ((KGraphData) target).setProperty(KlighdInternalProperties.MODEL_ELEMENT, source);
 
         } else if (KGraphPackage.eINSTANCE.getKGraphElement().isInstance(target)) {
-            ((KGraphElement) target).setProperty(KlighdInternalProperties.MODEL_ELEMEMT, source);
+            ((KGraphElement) target).setProperty(KlighdInternalProperties.MODEL_ELEMENT, source);
         }
     }
 

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdLayoutConfigurationStore.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdLayoutConfigurationStore.java
@@ -283,7 +283,7 @@ public class KlighdLayoutConfigurationStore implements ILayoutConfigurationStore
                 final String msg = "Concurrent modification in KGraphPropertyLayoutConfig:"
                         + Klighd.LINE_SEPARATOR + "  element == " + graphElement
                         + Klighd.LINE_SEPARATOR + "  sourceElement == "
-                        + graphElement.getProperty(KlighdInternalProperties.MODEL_ELEMEMT);
+                        + graphElement.getProperty(KlighdInternalProperties.MODEL_ELEMENT);
 
                 Klighd.log(new Status(IStatus.ERROR, Klighd.PLUGIN_ID, msg));
             }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/util/KlighdInternalProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/util/KlighdInternalProperties.java
@@ -47,7 +47,14 @@ public final class KlighdInternalProperties {
      * KGraphData}, for {@link de.cau.cs.kieler.klighd.kgraph.KGraphElement KGraphElements} it is to
      * be attached to their layout data.
      */
-    public static final IProperty<Object> MODEL_ELEMEMT = new Property<Object>("klighd.modelElement");
+    public static final IProperty<Object> MODEL_ELEMENT = new Property<Object>("klighd.modelElement");
+    
+    /**
+     * Deprecated property with a typo, see {@link #MODEL_ELEMENT} as the replacement.
+     * 
+     * @deprecated
+     */
+    public static final IProperty<Object> MODEL_ELEMEMT = MODEL_ELEMENT;
 
     /**
      * Property indicating that the node has been populated. A node is populated, if and only if the

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/util/SourceModelTrackingAdapter.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/util/SourceModelTrackingAdapter.java
@@ -53,7 +53,7 @@ public class SourceModelTrackingAdapter extends EContentAdapter {
     private static final Predicate<Object> CANDIDATES = KlighdPredicates.instanceOf(
             KGraphElement.class, KRendering.class, IPropertyToObjectMapImpl.class);
     
-    private static final IProperty<Object> MODEL_ELEMENT = KlighdInternalProperties.MODEL_ELEMEMT;
+    private static final IProperty<Object> MODEL_ELEMENT = KlighdInternalProperties.MODEL_ELEMENT;
 
     private Object mapsMonitor = this;
     private Multimap<Object, EObject> sourceTargetsMap = ArrayListMultimap.create();

--- a/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/IncrementalUpdateTest.java
+++ b/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/IncrementalUpdateTest.java
@@ -168,7 +168,7 @@ public class IncrementalUpdateTest {
         
         final KNode newNode = KGraphUtil.createInitializedNode();
         final EObject newNodeSource = new EObjectImpl() { };
-        newNode.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource);
+        newNode.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource);
         final int newNodePosition = 0;
         
         newGraph.getChildren().add(newNodePosition, newNode);
@@ -208,9 +208,9 @@ public class IncrementalUpdateTest {
         final EObject newNodeSource0 = new EObjectImpl() { };
         final EObject newNodeSource1 = new EObjectImpl() { };
         final EObject newNodeSource2 = new EObjectImpl() { };
-        newNode0.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource0);
-        newNode1.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource1);
-        newNode2.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource2);
+        newNode0.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource0);
+        newNode1.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource1);
+        newNode2.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource2);
         final int newNode0Position = 0;
         final int newNode1Position = 1;
         final int newNode2Position = 2;
@@ -253,7 +253,7 @@ public class IncrementalUpdateTest {
         final KNode baseGraph = createTestGraph();
         final KNode baseNodeToRemove = baseGraph.getChildren().get(toRemovePosition);
         final EObject baseNodeToRemoveSource = new EObjectImpl() { };
-        baseNodeToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, baseNodeToRemoveSource);
+        baseNodeToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, baseNodeToRemoveSource);
         
         final KNode newGraph = createTestGraph();
         
@@ -281,11 +281,11 @@ public class IncrementalUpdateTest {
         final KNode baseGraph = createTestGraph();
         final KNode baseNodeToMove = baseGraph.getChildren().get(oldPosition);
         final EObject nodeToMoveSource = new EObjectImpl() { };
-        baseNodeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, nodeToMoveSource);
+        baseNodeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, nodeToMoveSource);
         
         final KNode newGraph = createTestGraph();
         final KNode newNodeToMove = newGraph.getChildren().get(oldPosition);
-        newNodeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, nodeToMoveSource);
+        newNodeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, nodeToMoveSource);
         newGraph.getChildren().move(newPosition, newNodeToMove);
         
         
@@ -314,7 +314,7 @@ public class IncrementalUpdateTest {
         
         final KPort newPort = KGraphUtil.createInitializedPort();
         final EObject newPortSource = new EObjectImpl() { };
-        newPort.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newPortSource);
+        newPort.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newPortSource);
         final int parentNodePosition = 0;
         final int newPortPosition = 0;
         
@@ -346,7 +346,7 @@ public class IncrementalUpdateTest {
         final KNode baseGraph = createTestGraph();
         final KPort basePortToRemove = baseGraph.getChildren().get(parentNodePosition).getPorts().get(toRemovePosition);
         final EObject basePortToRemoveSource = new EObjectImpl() { };
-        basePortToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, basePortToRemoveSource);
+        basePortToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, basePortToRemoveSource);
         
         final KNode newGraph = createTestGraph();
         
@@ -375,11 +375,11 @@ public class IncrementalUpdateTest {
         final KNode baseGraph = createTestGraph();
         final KPort basePortToMove = baseGraph.getChildren().get(parentNodePosition).getPorts().get(oldPosition);
         final EObject portToMoveSource = new EObjectImpl() { };
-        basePortToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, portToMoveSource);
+        basePortToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, portToMoveSource);
         
         final KNode newGraph = createTestGraph();
         final KPort newPortToMove = newGraph.getChildren().get(parentNodePosition).getPorts().get(oldPosition);
-        newPortToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, portToMoveSource);
+        newPortToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, portToMoveSource);
         newGraph.getChildren().get(parentNodePosition).getPorts().move(newPosition, newPortToMove);
         
         
@@ -412,7 +412,7 @@ public class IncrementalUpdateTest {
         final KNode parentNode = newGraph.getChildren().get(parentNodePosition);
         final KLabel newLabel = KGraphUtil.createInitializedLabel(parentNode);
         final EObject newLabelSource = new EObjectImpl() { };
-        newLabel.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newLabelSource);
+        newLabel.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newLabelSource);
         parentNode.getLabels().move(newLabelPosition, newLabel);
         
         final ViewContext viewContext = createViewContext();
@@ -441,7 +441,7 @@ public class IncrementalUpdateTest {
         final KNode baseGraph = createTestGraph();
         final KLabel baseLabelToRemove = baseGraph.getChildren().get(parentNodePosition).getLabels().get(toRemovePosition);
         final EObject baseLabelToRemoveSource = new EObjectImpl() { };
-        baseLabelToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, baseLabelToRemoveSource);
+        baseLabelToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, baseLabelToRemoveSource);
         
         final KNode newGraph = createTestGraph();
         
@@ -470,11 +470,11 @@ public class IncrementalUpdateTest {
         final KNode baseGraph = createTestGraph();
         final KLabel baseLabelToMove = baseGraph.getChildren().get(parentNodePosition).getLabels().get(oldPosition);
         final EObject labelToMoveSource = new EObjectImpl() { };
-        baseLabelToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, labelToMoveSource);
+        baseLabelToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, labelToMoveSource);
         
         final KNode newGraph = createTestGraph();
         final KLabel newLabelToMove = newGraph.getChildren().get(parentNodePosition).getLabels().get(oldPosition);
-        newLabelToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, labelToMoveSource);
+        newLabelToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, labelToMoveSource);
         newGraph.getChildren().get(parentNodePosition).getLabels().move(newPosition, newLabelToMove);
         
         
@@ -505,7 +505,7 @@ public class IncrementalUpdateTest {
         
         final KEdge newEdge = KGraphUtil.createInitializedEdge();
         final EObject newEdgeSource = new EObjectImpl() { };
-        newEdge.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newEdgeSource);
+        newEdge.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newEdgeSource);
         
         final int sourceNodePosition = 0;
         final int targetNodePosition = 1;
@@ -548,7 +548,7 @@ public class IncrementalUpdateTest {
         
         final KEdge newEdge = KGraphUtil.createInitializedEdge();
         final EObject newEdgeSource = new EObjectImpl() { };
-        newEdge.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newEdgeSource);
+        newEdge.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newEdgeSource);
         
         final int sourceNodePosition = 0;
         final int targetNodePosition = 1;
@@ -598,7 +598,7 @@ public class IncrementalUpdateTest {
         // Create a new source node on index 0.
         final KNode newSourceNode = KGraphUtil.createInitializedNode();
         final EObject newSourceNodeSource = new EObjectImpl() { };
-        newSourceNode.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newSourceNodeSource);
+        newSourceNode.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newSourceNodeSource);
         final int newSourceNodePosition = 0;
         
         newGraph.getChildren().add(newSourceNodePosition, newSourceNode);
@@ -606,7 +606,7 @@ public class IncrementalUpdateTest {
         // Create the new target port on another node with index 1.
         final KPort newTargetPort = KGraphUtil.createInitializedPort();
         final EObject newTargetPortSource = new EObjectImpl() { };
-        newTargetPort.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newTargetPortSource);
+        newTargetPort.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newTargetPortSource);
         final int targetNodePosition = 1;
         final int newTargetPortPosition = 0;
         
@@ -616,7 +616,7 @@ public class IncrementalUpdateTest {
         // Create a new edge from the new source node to the new target port.
         final KEdge newEdge = KGraphUtil.createInitializedEdge();
         final EObject newEdgeSource = new EObjectImpl() { };
-        newEdge.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newEdgeSource);
+        newEdge.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newEdgeSource);
         
         newEdge.setSource(newSourceNode);
         newEdge.setTargetPort(newTargetPort);
@@ -684,7 +684,7 @@ public class IncrementalUpdateTest {
         final KEdge baseEdgeToRemove = baseGraph.getChildren().get(sourceNodePosition).getOutgoingEdges()
             .get(toRemovePosition);
         final EObject baseEdgeToRemoveSource = new EObjectImpl() { };
-        baseEdgeToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, baseEdgeToRemoveSource);
+        baseEdgeToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, baseEdgeToRemoveSource);
         
         final KNode newGraph = createTestGraph();
         
@@ -714,7 +714,7 @@ public class IncrementalUpdateTest {
         final KEdge baseEdgeToRemove = baseGraph.getChildren().get(sourceNodePosition).getPorts()
             .get(sourceNodePortPosition).getEdges().get(toRemovePosition);
         final EObject baseEdgeToRemoveSource = new EObjectImpl() { };
-        baseEdgeToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, baseEdgeToRemoveSource);
+        baseEdgeToRemove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, baseEdgeToRemoveSource);
         
         final KNode newGraph = createTestGraph();
         
@@ -746,12 +746,12 @@ public class IncrementalUpdateTest {
         final KEdge baseEdgeToMove = baseGraph.getChildren().get(sourceNodePosition).getOutgoingEdges()
             .get(oldSourcePosition);
         final EObject edgeToMoveSource = new EObjectImpl() { };
-        baseEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, edgeToMoveSource);
+        baseEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, edgeToMoveSource);
         
         final KNode newGraph = createTestGraph();
         final KEdge newEdgeToMove = newGraph.getChildren().get(sourceNodePosition).getOutgoingEdges()
             .get(oldSourcePosition);
-        newEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, edgeToMoveSource);
+        newEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, edgeToMoveSource);
         final KNode newTargetNode = newEdgeToMove.getTarget();
         newGraph.getChildren().get(sourceNodePosition).getOutgoingEdges().move(newSourcePosition, newEdgeToMove);
         newTargetNode.getIncomingEdges().move(newTargetPosition, newEdgeToMove);
@@ -789,12 +789,12 @@ public class IncrementalUpdateTest {
         final KEdge baseEdgeToMove = baseGraph.getChildren().get(sourceNodePosition).getPorts()
             .get(sourceNodePortPosition).getEdges().get(oldSourcePosition);
         final EObject edgeToMoveSource = new EObjectImpl() { };
-        baseEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, edgeToMoveSource);
+        baseEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, edgeToMoveSource);
         
         final KNode newGraph = createTestGraph();
         final KEdge newEdgeToMove = newGraph.getChildren().get(sourceNodePosition).getPorts()
             .get(sourceNodePortPosition).getEdges().get(oldSourcePosition);
-        newEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, edgeToMoveSource);
+        newEdgeToMove.setProperty(KlighdInternalProperties.MODEL_ELEMENT, edgeToMoveSource);
         final KPort newTargetPort = newEdgeToMove.getTargetPort();
         newGraph.getChildren().get(sourceNodePosition).getPorts().get(sourceNodePortPosition).getEdges()
             .move(newSourcePosition, newEdgeToMove);
@@ -897,11 +897,11 @@ public class IncrementalUpdateTest {
         final EObject newNodeSource3 = new EObjectImpl() { };
         final EObject newNodeSourceL = new EObjectImpl() { };
         final EObject newNodeSource2 = new EObjectImpl() { };
-        newNodeC.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSourceC);
-        newNode1.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource1);
-        newNode3.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource3);
-        newNodeL.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSourceL);
-        newNode2.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, newNodeSource2);
+        newNodeC.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSourceC);
+        newNode1.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource1);
+        newNode3.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource3);
+        newNodeL.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSourceL);
+        newNode2.setProperty(KlighdInternalProperties.MODEL_ELEMENT, newNodeSource2);
 
         final KPort newPortCOut = KGraphUtil.createInitializedPort();
         newPortCOut.setNode(newNodeC);

--- a/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/ViewContextSourceModelTrackingTest.java
+++ b/test/de.cau.cs.kieler.klighd.test/src/de/cau/cs/kieler/klighd/test/ViewContextSourceModelTrackingTest.java
@@ -108,11 +108,11 @@ public class ViewContextSourceModelTrackingTest {
     public void test00() {
         final Object elementB = new Object();
         final KNode nodeB = KGraphUtil.createInitializedNode();        
-        nodeB.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, elementB);
+        nodeB.setProperty(KlighdInternalProperties.MODEL_ELEMENT, elementB);
         
         final Object elementA = new Object();
         final KNode nodeA = KGraphUtil.createInitializedNode();
-        nodeA.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, elementA);
+        nodeA.setProperty(KlighdInternalProperties.MODEL_ELEMENT, elementA);
         nodeA.getChildren().add(nodeB);
 
         final KNode root = KGraphUtil.createInitializedNode();
@@ -160,7 +160,7 @@ public class ViewContextSourceModelTrackingTest {
 
         final EObject sourceModel = new EObjectImpl() { };
         final KNode newModel = KGraphUtil.createInitializedNode();
-        newModel.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, sourceModel);
+        newModel.setProperty(KlighdInternalProperties.MODEL_ELEMENT, sourceModel);
         
         UPDATE_STRATEGY.update(viewModel, newModel, viewContext);
         
@@ -484,8 +484,8 @@ public class ViewContextSourceModelTrackingTest {
         final EObject rootSource = new EObjectImpl() { };
         final EObject childSource = new EObjectImpl() { };
 
-        rootNode.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, rootSource);
-        childNode.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, childSource);
+        rootNode.setProperty(KlighdInternalProperties.MODEL_ELEMENT, rootSource);
+        childNode.setProperty(KlighdInternalProperties.MODEL_ELEMENT, childSource);
 
         final ViewContext viewContext = createViewContext();
         INCREMENTAL_UPDATE_STRATEGY.update(viewContext.getViewModel(), rootNode, viewContext);
@@ -498,8 +498,8 @@ public class ViewContextSourceModelTrackingTest {
         final KNode newRoot = createSimpleNetwork();
         final KNode newChildNode = newRoot.getChildren().get(1);
 
-        newRoot.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, rootSource);
-        newChildNode.setProperty(KlighdInternalProperties.MODEL_ELEMEMT, childSource);
+        newRoot.setProperty(KlighdInternalProperties.MODEL_ELEMENT, rootSource);
+        newChildNode.setProperty(KlighdInternalProperties.MODEL_ELEMENT, childSource);
 
         final ViewContext newViewContext = createViewContext();
         INCREMENTAL_UPDATE_STRATEGY.update(newViewContext.getViewModel(), newRoot, newViewContext);


### PR DESCRIPTION
This typo was bugging me for quite some time, now it is no longer. To not break the API of any dependent projects, the old property is still kept as a deprecated property, pointing to the same object as the new one. This leaves us the option to replace the property entirely in some future release.