### PR TITLE
Remove Code Obsolete after Sprotty Update

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
@@ -57,15 +57,7 @@ import org.eclipse.elk.graph.properties.IProperty
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.sprotty.Action
 import org.eclipse.sprotty.ActionMessage
-import org.eclipse.sprotty.ComputedBoundsApplicator
-import org.eclipse.sprotty.IDiagramExpansionListener
-import org.eclipse.sprotty.IDiagramOpenListener
-import org.eclipse.sprotty.IDiagramSelectionListener
-import org.eclipse.sprotty.ILayoutEngine
-import org.eclipse.sprotty.IModelUpdateListener
-import org.eclipse.sprotty.IPopupModelFactory
 import org.eclipse.sprotty.RejectAction
-import org.eclipse.sprotty.SModelCloner
 import org.eclipse.sprotty.SModelElement
 import org.eclipse.sprotty.SModelRoot
 import org.eclipse.sprotty.SelectAction
@@ -455,49 +447,5 @@ class KGraphDiagramServer extends LanguageAwareDiagramServer {
             updateModel(currentRoot)
         }
         newModel = false
-    }
-    
-    // Repeat injection of multiple methods of the DefaultDiagramServer as the javax.inject->jakarta.inject transition
-    // broke something here.
-    // TODO: remove when not necessary anymore
-    
-    @Inject
-    override setModelUpdateListener(IModelUpdateListener listener) {
-        super.modelUpdateListener = listener;
-    }
-    
-    @Inject
-    override setLayoutEngine(ILayoutEngine engine) {
-        super.layoutEngine = engine;
-    }
-    
-    @Inject
-    override setComputedBoundsApplicator(ComputedBoundsApplicator computedBoundsApplicator) {
-        super.computedBoundsApplicator = computedBoundsApplicator;
-    }
-    
-    @Inject
-    override setPopupModelFactory(IPopupModelFactory factory) {
-        super.popupModelFactory = factory;
-    }
-    
-    @Inject
-    override setSelectionListener(IDiagramSelectionListener listener) {
-        super.selectionListener = listener;
-    }
-    
-    @Inject
-    override setExpansionListener(IDiagramExpansionListener diagramExpansionListener) {
-        super.expansionListener = diagramExpansionListener;
-    }
-    
-    @Inject
-    override setOpenListener(IDiagramOpenListener diagramOpenListener) {
-        super.openListener = diagramOpenListener;
-    }
-    
-    @Inject 
-    override setSModelCloner(SModelCloner smodelCloner) {
-        super.SModelCloner = smodelCloner;
     }
 }

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLayoutEngine.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLayoutEngine.xtend
@@ -3,7 +3,7 @@
  * 
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2023 by
+ * Copyright 2018-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -18,6 +18,7 @@ package de.cau.cs.kieler.klighd.lsp
 
 import com.google.inject.Inject
 import de.cau.cs.kieler.klighd.LightDiagramLayoutConfig
+import de.cau.cs.kieler.klighd.lsp.launch.AbstractLanguageServer
 import de.cau.cs.kieler.klighd.lsp.utils.KGraphMappingUtil
 import de.cau.cs.kieler.klighd.lsp.utils.RenderingPreparer
 import java.io.ByteArrayOutputStream
@@ -48,16 +49,18 @@ class KGraphLayoutEngine extends ElkLayoutEngine {
 	public static val LOG = Logger.getLogger(KGraphLayoutEngine)
 	
 	override layout(SModelRoot root, Action cause) {
-	    synchronized (diagramState) {
-    	    if (root instanceof SGraph) {
-    	        // The layout is executed on the KGraph, not the SGraph. So get the KGraph belonging to this SGraph from
-    	        // the KGraphContext.
-                onlyLayoutOnKGraph(root.id)
-
-                // map layouted KGraph to SGraph
-                KGraphMappingUtil.mapLayout(diagramState.getKGraphToSModelElementMap(root.id))
+	    AbstractLanguageServer.addToMainThreadQueue([
+    	    synchronized (diagramState) {
+        	    if (root instanceof SGraph) {
+        	        // The layout is executed on the KGraph, not the SGraph. So get the KGraph belonging to this SGraph from
+        	        // the KGraphContext.
+                    onlyLayoutOnKGraph(root.id)
+    
+                    // map layouted KGraph to SGraph
+                    KGraphMappingUtil.mapLayout(diagramState.getKGraphToSModelElementMap(root.id))
+                }
             }
-        }
+        ])
     }
 
     /**

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
@@ -240,36 +240,6 @@ class RefreshLayoutAction implements Action {
 }
 
 /**
- * Updates the model and sends the cause to the client.
- * Extends to UpdateModelAction.
- * FIXME Remove this if the UpdateModelAction includes a cause.
- * 
- * @author sdo
- */
-@Accessors
-@EqualsHashCode
-@ToString(skipNulls = true)
-public class KeithUpdateModelAction extends UpdateModelAction {
-    public static val KIND = 'updateModel'
-    String kind = KIND
-    
-    
-    SModelRoot newRoot
-    Boolean animate
-    Action cause
-    
-    new() {}
-    new(Consumer<KeithUpdateModelAction> initializer) {
-        initializer.accept(this)
-    }
-    
-    new(SModelRoot newRoot, Action cause) {
-        this.newRoot = newRoot
-        this.cause = cause
-    }
-}
-
-/**
  * Sent from client to request a certain piece of the diagram.
  * 
  * @author mka


### PR DESCRIPTION
The update to Sprotty 1.1.1 brought its injection framework up to the new javax->jakarta change, thus making the re-injections obsolete. Furthermore, remove older FIXMEs that are resolved as the UpdateModelAction contains a cause for some time now.