### PR TITLE
kgraph: skip parsing unparsable layout options

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.kgraph/src/de/cau/cs/kieler/klighd/kgraph/util/KGraphDataUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd.kgraph/src/de/cau/cs/kieler/klighd/kgraph/util/KGraphDataUtil.java
@@ -299,9 +299,13 @@ public final class KGraphDataUtil {
 
             // if we have a valid layout option, parse its value.
             if (layoutOptionData != null) {
-                Object layoutOptionValue = layoutOptionData.parseValue(value);
-                if (layoutOptionValue != null) {
-                    propertyHolder.setProperty(layoutOptionData, layoutOptionValue);
+                try {
+                    Object layoutOptionValue = layoutOptionData.parseValue(value);
+                    if (layoutOptionValue != null) {
+                        propertyHolder.setProperty(layoutOptionData, layoutOptionValue);
+                    }
+                } catch (IllegalStateException e) {
+                    // Some options cannot be parsed, skip these.
                 }
             } else {
                 


### PR DESCRIPTION
when parsing layout options from persistent entries back to properties, some object valued options cannot be parsed and will throw IllegalStateExceptions, which are not caught anywhere. Non-parsable properties are now just skipped without erroring.