### PR TITLE
krendering.extensions: remove non-direct dependency to jakarta.inject

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.krendering.extensions/META-INF/MANIFEST.MF
+++ b/plugins/de.cau.cs.kieler.klighd.krendering.extensions/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 2.3.1.qualifier
 Bundle-Activator: de.cau.cs.kieler.klighd.krendering.extensions.KRenderingExtensionsPlugin
 Bundle-Vendor: Kiel University
 Require-Bundle: org.eclipse.core.runtime,
- jakarta.inject.jakarta.inject-api;bundle-version="2.0.1",
  com.google.inject;bundle-version="3.0.0",
  org.eclipse.xtext.xbase.lib;bundle-version="2.4.0",
  org.eclipse.elk.core;bundle-version="0.1.0",


### PR DESCRIPTION
the same dependency to jakarta.inject from de.cau.cs.kieler.klighd cannot be removed, as com.google.inject does not re-export that dependency, requiring either a package import or this direct dependency.