### PR TITLE
Fix GH Actions builds on release branches

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -50,10 +50,19 @@ jobs:
         retention-days: 14
         if-no-files-found: error
     - name: Archive MVN Repository
+      if: ${{ !contains(github.ref, 'releases-') }}
       uses: actions/upload-artifact@v2
       with:
         name: KLighD MVN Repository
         path: klighd-snapshots/**/*
+        retention-days: 14
+        if-no-files-found: error
+    - name: Archive MVN Release Repository
+      if: ${{ contains(github.ref, 'releases-') }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: KLighD MVN Repository
+        path: klighd/**/*
         retention-days: 14
         if-no-files-found: error
     - name: Publish Test Report


### PR DESCRIPTION
On release branches, look up the `klighd` instead of the `klighd-snapshots` for the Maven repository.

Fixes #163