### PR TITLE
lsp: create source jar in build

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/pom.xml
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/pom.xml
@@ -215,6 +215,26 @@
         <groupId>org.eclipse.xtend</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
       </plugin>
+      <!-- Add sources -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- make sure the source jar is also signed, putting the signing after it. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
While making LSP a plain maven artifact, it lost its previous configuration to add sources. This adds it back in.