### PR TITLE
lsp: include the META-INF/services folder in maven artifacts.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/pom.xml
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/pom.xml
@@ -204,11 +204,6 @@
   
   <build>
     <sourceDirectory>src</sourceDirectory>
-    <resources>
-      <resource>
-        <directory>src/resources</directory>
-      </resource>
-    </resources>
     <plugins>
       <!-- Compile Xtend code -->
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,15 @@
 
   <!-- Modify the build process to add Tycho and configure some utility plug-ins. -->
   <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+         <includes>
+           <include>META-INF/services/**</include>
+         </includes>
+      </resource>
+    </resources>
+
     <sourceDirectory>src</sourceDirectory>
     <plugins>
       <!-- we need tycho plugin to build eclipse plugins -->


### PR DESCRIPTION
In the last 3.0.1 release, the .lsp module does not include the META-INF/services folder anymore, thus not including important configuration of the new interactive and the top-down layout features. This PR configures the maven build to always include that folder for any module that is not a plugin as well (so the .lsp module).