### PR TITLE
lsp: remove outermost padding to remove border when exporting SVGs.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLayoutEngine.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLayoutEngine.xtend
@@ -24,6 +24,8 @@ import de.cau.cs.kieler.klighd.lsp.utils.RenderingPreparer
 import java.io.ByteArrayOutputStream
 import java.util.ArrayList
 import org.apache.log4j.Logger
+import org.eclipse.elk.core.math.ElkPadding
+import org.eclipse.elk.core.options.CoreOptions
 import org.eclipse.elk.graph.ElkNode
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
@@ -70,6 +72,8 @@ class KGraphLayoutEngine extends ElkLayoutEngine {
      */
     def onlyLayoutOnKGraph(String uri) {
         val kGraphContext = diagramState.getKGraphContext(uri)
+        // Remove any padding from the root node to avoid blank padding around the edge of the entire graph.
+        kGraphContext.viewModel.setProperty(CoreOptions.PADDING, new ElkPadding(0))
 
         // layout of KGraph
         val lightDiagramLayoutConfig = new LightDiagramLayoutConfig(kGraphContext)


### PR DESCRIPTION
Usually when exporting the graph with Sprotty, we just export the entire graph as-is. ELK has a default value for its padding of 12 pixels, which is also applied to the outermost invisible graph node, shifting all elements inwards by these 12 pixels.
This fix avoids that issue by removing the outermost padding before the layout on any graph, as that would be invisible anyways. With this, exported graphs will always be snug around the outermost graph elements.

Fixes kieler/klighd-vscode#46.