### PR TITLE
Remove unused imports in Java and xtend classes

### DIFF
--- a/plugins/de.cau.cs.kieler.kgraph.text/src-gen/de/cau/cs/kieler/kgraph/text/services/GRandomGrammarAccess.java
+++ b/plugins/de.cau.cs.kieler.kgraph.text/src-gen/de/cau/cs/kieler/kgraph/text/services/GRandomGrammarAccess.java
@@ -3,9 +3,8 @@
  */
 package de.cau.cs.kieler.kgraph.text.services;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import java.util.List;
+
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Alternatives;
 import org.eclipse.xtext.Assignment;
@@ -20,9 +19,11 @@ import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.UnorderedGroup;
 import org.eclipse.xtext.common.services.TerminalsGrammarAccess;
-import org.eclipse.xtext.service.AbstractElementFinder.AbstractEnumRuleElementFinder;
 import org.eclipse.xtext.service.AbstractElementFinder.AbstractGrammarElementFinder;
 import org.eclipse.xtext.service.GrammarProvider;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 @Singleton
 public class GRandomGrammarAccess extends AbstractGrammarElementFinder {

--- a/plugins/de.cau.cs.kieler.kgraph.text/src-gen/de/cau/cs/kieler/kgraph/text/services/KGraphGrammarAccess.java
+++ b/plugins/de.cau.cs.kieler.kgraph.text/src-gen/de/cau/cs/kieler/kgraph/text/services/KGraphGrammarAccess.java
@@ -3,9 +3,8 @@
  */
 package de.cau.cs.kieler.kgraph.text.services;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import java.util.List;
+
 import org.eclipse.xtext.Action;
 import org.eclipse.xtext.Alternatives;
 import org.eclipse.xtext.Assignment;
@@ -20,9 +19,11 @@ import org.eclipse.xtext.ParserRule;
 import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.UnorderedGroup;
-import org.eclipse.xtext.service.AbstractElementFinder.AbstractEnumRuleElementFinder;
 import org.eclipse.xtext.service.AbstractElementFinder.AbstractGrammarElementFinder;
 import org.eclipse.xtext.service.GrammarProvider;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 @Singleton
 public class KGraphGrammarAccess extends AbstractGrammarElementFinder {

--- a/plugins/de.cau.cs.kieler.klighd.kgraph/src/de/cau/cs/kieler/klighd/kgraph/util/KGraphUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd.kgraph/src/de/cau/cs/kieler/klighd/kgraph/util/KGraphUtil.java
@@ -31,7 +31,6 @@ import org.eclipse.elk.core.util.ElkUtil;
 import org.eclipse.elk.graph.ElkEdge;
 import org.eclipse.elk.graph.ElkGraphElement;
 import org.eclipse.elk.graph.ElkNode;
-import org.eclipse.elk.graph.ElkPort;
 import org.eclipse.elk.graph.util.ElkGraphUtil;
 import org.eclipse.emf.common.util.AbstractTreeIterator;
 import org.eclipse.emf.common.util.TreeIterator;

--- a/plugins/de.cau.cs.kieler.klighd.krendering/src-custom/de/cau/cs/kieler/klighd/krendering/KRenderingOptions.java
+++ b/plugins/de.cau.cs.kieler.klighd.krendering/src-custom/de/cau/cs/kieler/klighd/krendering/KRenderingOptions.java
@@ -16,8 +16,8 @@
  */
 package de.cau.cs.kieler.klighd.krendering;
 
-import de.cau.cs.kieler.klighd.krendering.KRendering;
 import java.util.EnumSet;
+
 import org.eclipse.elk.core.data.ILayoutMetaDataProvider;
 import org.eclipse.elk.core.data.LayoutOptionData;
 import org.eclipse.elk.graph.properties.IProperty;

--- a/plugins/de.cau.cs.kieler.klighd.krendering/src/de/cau/cs/kieler/klighd/krendering/impl/KRenderingImpl.java
+++ b/plugins/de.cau.cs.kieler.klighd.krendering/src/de/cau/cs/kieler/klighd/krendering/impl/KRenderingImpl.java
@@ -16,12 +16,17 @@
  */
 package de.cau.cs.kieler.klighd.krendering.impl;
 
-import de.cau.cs.kieler.klighd.kgraph.EMapPropertyHolder;
-import de.cau.cs.kieler.klighd.kgraph.KGraphData;
-import de.cau.cs.kieler.klighd.kgraph.KGraphPackage;
-import de.cau.cs.kieler.klighd.kgraph.PersistentEntry;
+import java.util.Collection;
 
-import de.cau.cs.kieler.klighd.kgraph.impl.IPropertyToObjectMapImpl;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.common.notify.NotificationChain;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.InternalEObject;
+import org.eclipse.emf.ecore.impl.ENotificationImpl;
+import org.eclipse.emf.ecore.util.EObjectContainmentEList;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.emf.ecore.util.InternalEList;
 
 import de.cau.cs.kieler.klighd.kgraph.impl.KGraphDataImpl;
 import de.cau.cs.kieler.klighd.krendering.KAction;
@@ -29,31 +34,8 @@ import de.cau.cs.kieler.klighd.krendering.KContainerRendering;
 import de.cau.cs.kieler.klighd.krendering.KPlacementData;
 import de.cau.cs.kieler.klighd.krendering.KRendering;
 import de.cau.cs.kieler.klighd.krendering.KRenderingPackage;
-
 import de.cau.cs.kieler.klighd.krendering.KStyle;
 import de.cau.cs.kieler.klighd.krendering.KStyleHolder;
-import java.util.Collection;
-import java.util.Map;
-
-import org.eclipse.elk.graph.properties.IProperty;
-import org.eclipse.elk.graph.properties.IPropertyHolder;
-
-import org.eclipse.emf.common.notify.Notification;
-import org.eclipse.emf.common.notify.NotificationChain;
-
-import org.eclipse.emf.common.util.EList;
-import org.eclipse.emf.common.util.EMap;
-
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.InternalEObject;
-
-import org.eclipse.emf.ecore.impl.ENotificationImpl;
-
-import org.eclipse.emf.ecore.util.EObjectContainmentEList;
-import org.eclipse.emf.ecore.util.EcoreEMap;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.emf.ecore.util.InternalEList;
 
 /**
  * <!-- begin-user-doc -->

--- a/plugins/de.cau.cs.kieler.klighd.krendering/src/de/cau/cs/kieler/klighd/krendering/impl/KRenderingPackageImpl.java
+++ b/plugins/de.cau.cs.kieler.klighd.krendering/src/de/cau/cs/kieler/klighd/krendering/impl/KRenderingPackageImpl.java
@@ -16,10 +16,18 @@
  */
 package de.cau.cs.kieler.klighd.krendering.impl;
 
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EDataType;
+import org.eclipse.emf.ecore.EEnum;
+import org.eclipse.emf.ecore.EGenericType;
+import org.eclipse.emf.ecore.EOperation;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.ETypeParameter;
+import org.eclipse.emf.ecore.impl.EPackageImpl;
+
 import de.cau.cs.kieler.klighd.kgraph.KGraphPackage;
-
-import de.cau.cs.kieler.klighd.kgraph.impl.KGraphPackageImpl;
-
 import de.cau.cs.kieler.klighd.krendering.Arc;
 import de.cau.cs.kieler.klighd.krendering.Colors;
 import de.cau.cs.kieler.klighd.krendering.HorizontalAlignment;
@@ -85,18 +93,6 @@ import de.cau.cs.kieler.klighd.krendering.ModifierState;
 import de.cau.cs.kieler.klighd.krendering.Trigger;
 import de.cau.cs.kieler.klighd.krendering.Underline;
 import de.cau.cs.kieler.klighd.krendering.VerticalAlignment;
-
-import org.eclipse.emf.ecore.EAttribute;
-import org.eclipse.emf.ecore.EClass;
-import org.eclipse.emf.ecore.EDataType;
-import org.eclipse.emf.ecore.EEnum;
-import org.eclipse.emf.ecore.EGenericType;
-import org.eclipse.emf.ecore.EOperation;
-import org.eclipse.emf.ecore.EPackage;
-import org.eclipse.emf.ecore.EReference;
-import org.eclipse.emf.ecore.ETypeParameter;
-
-import org.eclipse.emf.ecore.impl.EPackageImpl;
 
 /**
  * <!-- begin-user-doc -->

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
@@ -50,7 +50,6 @@ import java.util.List
 import org.apache.log4j.Logger
 import org.eclipse.elk.alg.layered.options.LayeredOptions
 import org.eclipse.elk.core.options.CoreOptions
-import org.eclipse.emf.ecore.EObject
 import org.eclipse.sprotty.Dimension
 import org.eclipse.sprotty.SEdge
 import org.eclipse.sprotty.SGraph

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
@@ -51,8 +51,6 @@ import java.util.List
 import java.util.Map
 import java.util.ServiceLoader
 import java.util.Set
-import java.util.concurrent.CompletableFuture
-import org.apache.log4j.Logger
 import org.eclipse.core.runtime.Platform
 import org.eclipse.elk.core.data.LayoutMetaDataService
 import org.eclipse.elk.core.data.LayoutOptionData

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/gson_utils/EObjectSerializer.xtend
@@ -20,7 +20,6 @@ import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
-import de.cau.cs.kieler.klighd.KlighdDataManager
 import de.cau.cs.kieler.klighd.kgraph.EMapPropertyHolder
 import de.cau.cs.kieler.klighd.kgraph.KInsets
 import de.cau.cs.kieler.klighd.kgraph.impl.EMapPropertyHolderImpl

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
@@ -24,8 +24,6 @@ import org.eclipse.sprotty.Action
 import org.eclipse.sprotty.RequestAction
 import org.eclipse.sprotty.ResponseAction
 import org.eclipse.sprotty.SModelElement
-import org.eclipse.sprotty.SModelRoot
-import org.eclipse.sprotty.UpdateModelAction
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtend.lib.annotations.EqualsHashCode
 import org.eclipse.xtend.lib.annotations.ToString

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/ILayoutRecorder.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/ILayoutRecorder.java
@@ -20,7 +20,6 @@ import org.eclipse.elk.core.math.KVector;
 
 import de.cau.cs.kieler.klighd.ZoomStyle;
 import de.cau.cs.kieler.klighd.kgraph.KGraphElement;
-import de.cau.cs.kieler.klighd.kgraph.KNode;
 
 /**
  * A dedicated interface enable the separation of the features provided by

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/LabelManagementUtil.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/LabelManagementUtil.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.graphics.FontData;
 
 import com.google.common.collect.Iterators;
 
-import de.cau.cs.kieler.klighd.KlighdOptions;
 import de.cau.cs.kieler.klighd.krendering.KRendering;
 import de.cau.cs.kieler.klighd.krendering.KRenderingOptions;
 import de.cau.cs.kieler.klighd.krendering.KRenderingUtil;


### PR DESCRIPTION
Run the 'Organize imports' action on each class that has unused imports.

On some classes the re-order also existing and used imports. Do you have specific settings for the order of import statements (e.g. in Eclipse preferences: Java -> Code Style -> Organize Imports)? I just used the default settings for this. Please let me know if I should change them.