### PR TITLE
copy properties to the SModel already during initial SModel generation

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
@@ -60,6 +60,7 @@ import org.eclipse.sprotty.SPort
 import org.eclipse.sprotty.xtext.IDiagramGenerator
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.util.CancelIndicator
+import de.cau.cs.kieler.klighd.lsp.utils.KGraphMappingUtil
 
 /**
  * A diagram generator that can create Sprotty {@link SGraph} from any {@link Object} that has a registered view
@@ -259,6 +260,7 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
         nodeElement.data = node.data.filter[KRenderingLibrary.isAssignableFrom(it.class)].toList
         
         setProperties(nodeElement, node)
+        KGraphMappingUtil.mapProperties(node, nodeElement)
         findSpecialRenderings(filteredData)
         
         val renderingContextData = RenderingContextData.get(node)
@@ -311,6 +313,7 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
 
         val renderings = edge.data.filter[KRendering.isAssignableFrom(it.class)].toList
         
+        KGraphMappingUtil.mapProperties(edge, edgeElement)
         findSpecialRenderings(renderings)
         edgeElement.children.addAll(createLabels(edge.labels))
         edgeElement.junctionPoints = edge.getProperty(CoreOptions.JUNCTION_POINTS)
@@ -332,6 +335,7 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
         
         val renderings = port.data.filter [ KRendering.isAssignableFrom(it.class)].toList
         
+        KGraphMappingUtil.mapProperties(port, portElement)
         findSpecialRenderings(renderings)
         portElement.children.addAll(createLabels(port.labels))
 
@@ -353,6 +357,7 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
 
         val renderings = label.data.filter[KRendering.isAssignableFrom(it.class)].toList
 
+        KGraphMappingUtil.mapProperties(label, labelElement)
         findSpecialRenderings(renderings)
         // activate the element by default if it does not have an active/inactive status yet.
         val renderingContextData = RenderingContextData.get(label)

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2021 by
+ * Copyright 2018-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -40,6 +40,7 @@ import de.cau.cs.kieler.klighd.lsp.model.SKLabel
 import de.cau.cs.kieler.klighd.lsp.model.SKNode
 import de.cau.cs.kieler.klighd.lsp.model.SKPort
 import de.cau.cs.kieler.klighd.lsp.utils.KGraphElementIdGenerator
+import de.cau.cs.kieler.klighd.lsp.utils.KGraphMappingUtil
 import de.cau.cs.kieler.klighd.lsp.utils.SprottyProperties
 import de.cau.cs.kieler.klighd.util.KlighdPredicates
 import de.cau.cs.kieler.klighd.util.KlighdProperties
@@ -60,7 +61,6 @@ import org.eclipse.sprotty.SPort
 import org.eclipse.sprotty.xtext.IDiagramGenerator
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.util.CancelIndicator
-import de.cau.cs.kieler.klighd.lsp.utils.KGraphMappingUtil
 
 /**
  * A diagram generator that can create Sprotty {@link SGraph} from any {@link Object} that has a registered view

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramServer.xtend
@@ -353,6 +353,7 @@ class KGraphDiagramServer extends LanguageAwareDiagramServer {
      * Tells the server that the diagram should be refreshed.
      */
     protected def handle(RefreshDiagramAction action) {
+        getOptions().putAll(action.options)
         updateDiagram()
         return
     }

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramUpdater.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramUpdater.xtend
@@ -30,6 +30,7 @@ import de.cau.cs.kieler.klighd.lsp.launch.AbstractLanguageServer
 import de.cau.cs.kieler.klighd.lsp.model.RequestDiagramPieceAction
 import de.cau.cs.kieler.klighd.lsp.model.SKGraph
 import de.cau.cs.kieler.klighd.lsp.utils.KGraphMappingUtil
+import de.cau.cs.kieler.klighd.lsp.utils.RenderingPreparer
 import de.cau.cs.kieler.klighd.util.KlighdSynthesisProperties
 import java.util.HashSet
 import java.util.List
@@ -316,6 +317,7 @@ class KGraphDiagramUpdater extends DiagramUpdater {
         var SGraph sGraph = null;
         synchronized (diagramState) {
             sGraph = diagramGenerator.toSGraph(viewContext.viewModel, uri, cancelIndicator)
+            RenderingPreparer.prepareRenderingIDs(viewContext.viewModel, diagramGenerator.getKGraphToSModelElementMap)
         }
         if (incrementalDiagramGenerator) {
             val requestManager = new KGraphDiagramPieceRequestManager(diagramGenerator as KGraphIncrementalDiagramGenerator)

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLayoutEngine.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLayoutEngine.xtend
@@ -87,7 +87,7 @@ class KGraphLayoutEngine extends ElkLayoutEngine {
 
         synchronized (kGraphContext.viewModel) {
             lightDiagramLayoutConfig.performLayout
-            RenderingPreparer.prepareRendering(kGraphContext.viewModel, diagramState.getKGraphToSModelElementMap(uri))
+            RenderingPreparer.prepareRenderingLayout(kGraphContext.viewModel, diagramState.getKGraphToSModelElementMap(uri))
         }
     }
 

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/Actions.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2022 by
+ * Copyright 2018-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -18,6 +18,7 @@ package de.cau.cs.kieler.klighd.lsp.model
 
 import de.cau.cs.kieler.klighd.krendering.KImage
 import java.util.List
+import java.util.Map
 import java.util.Set
 import java.util.function.Consumer
 import org.eclipse.sprotty.Action
@@ -212,6 +213,8 @@ class PerformActionAction implements Action {
 class RefreshDiagramAction implements Action {
     public static val KIND = 'refreshDiagram'
     String kind = KIND
+    
+    Map<String, String> options
     
     new() {}
     new(Consumer<RefreshDiagramAction> initializer) {

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/KGraphModel.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/model/KGraphModel.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2022 by
+ * Copyright 2018-2024 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -39,6 +39,7 @@ abstract interface SKElement {
     def List<KGraphData> getData()
     def void setData(List<KGraphData> data)
     def HashMap<String, Object> getProperties()
+    def void setProperties(HashMap<String, Object> theProperties)
 }
 
 /**

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/utils/KGraphMappingUtil.xtend
@@ -23,6 +23,7 @@ import de.cau.cs.kieler.klighd.kgraph.KLabel
 import de.cau.cs.kieler.klighd.kgraph.KNode
 import de.cau.cs.kieler.klighd.kgraph.KPort
 import de.cau.cs.kieler.klighd.kgraph.KShapeLayout
+import de.cau.cs.kieler.klighd.kgraph.util.KGraphUtil
 import de.cau.cs.kieler.klighd.lsp.model.SKEdge
 import de.cau.cs.kieler.klighd.lsp.model.SKElement
 import de.cau.cs.kieler.klighd.lsp.model.SKLabel
@@ -39,7 +40,6 @@ import org.eclipse.sprotty.Dimension
 import org.eclipse.sprotty.Point
 import org.eclipse.sprotty.SModelElement
 import org.eclipse.sprotty.SShapeElement
-import de.cau.cs.kieler.klighd.kgraph.util.KGraphUtil
 
 /**
  * A helper class containing static methods for mapping of KGraph and SGraph bounds.
@@ -108,15 +108,7 @@ class KGraphMappingUtil {
         skEdge.junctionPoints.addAllAsCopies(0, kEdge.getProperty(CoreOptions.JUNCTION_POINTS))
         skEdge.junctionPoints.offset(new KVector(leftInset, topInset))
 
-        // map all properties excepts those that are blacklisted
-        // also include external whitelisted properties
-        var properties = kEdge.allProperties;
-
-        for (propertyKVPair : properties.entrySet()) {
-            if (keepProperty(propertyKVPair.key)) {
-                skEdge.properties.put(propertyKVPair.key.id, propertyKVPair.value)
-            }
-        }
+        mapProperties(kEdge, skEdge)
     }
     
     /**
@@ -138,11 +130,19 @@ class KGraphMappingUtil {
         skNode.position = new Point(kNode.xpos + leftInset, kNode.ypos + topInset)
         skNode.size = new Dimension(kNode.width, kNode.height)
 
-        var properties = kNode.allProperties;
+        mapProperties(kNode, skNode)
+    }
+    
+    /**
+     * Maps the properties of the KGraphElement to the corresponding SModelElement.
+     * Excepts those that are blacklisted, but also include whitelisted external properties.
+     */
+    static def mapProperties(KGraphElement kElement, SKElement sElement) {
+        val properties = kElement.allProperties
 
         for (propertyKVPair : properties.entrySet()) {
             if (keepProperty(propertyKVPair.key)) {
-                skNode.properties.put(propertyKVPair.key.id, propertyKVPair.value)
+                sElement.properties.put(propertyKVPair.key.id, propertyKVPair.value)
             }
         }
     }


### PR DESCRIPTION
for client-only layout.