### PR TITLE
[Build] Update actions to their latest version and build with Temurin

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: 17
-        distribution: adopt
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v4
       with:
@@ -43,7 +43,7 @@ jobs:
           #print the folder structure up to depth 2 on the console as we have no other option of getting an inside into workspace folder
           find . -maxdepth 2
     - name: Archive P2 Repository
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: KLighD P2 Repository
         path: build/de.cau.cs.kieler.klighd.repository/target/repository/**/*
@@ -51,7 +51,7 @@ jobs:
         if-no-files-found: error
     - name: Archive MVN Repository
       if: ${{ !contains(github.ref, 'releases-') }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: KLighD MVN Repository
         path: klighd-snapshots/**/*
@@ -59,7 +59,7 @@ jobs:
         if-no-files-found: error
     - name: Archive MVN Release Repository
       if: ${{ contains(github.ref, 'releases-') }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: KLighD MVN Repository
         path: klighd/**/*


### PR DESCRIPTION
The `adopt` distribution should not be used anymore. Instead `temurin` is recommended.
Quoting from https://github.com/actions/setup-java/?tab=readme-ov-file#supported-distributions
```
NOTE: AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate
workflows from adopt and adopt-openj9, to temurin and semeru respectively, to keep receiving software and security updates.
See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
```