### PR TITLE
[Build] Fix build plugin version warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -412,7 +411,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.11.2</version>
         <configuration>
           <source>8</source>
           <tags>
@@ -470,6 +469,19 @@
     <!-- the following definitions just register setups of plug-ins, their execution is enable elsewhere -->
     <pluginManagement>
      <plugins>
+
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.1.4</version>
+       </plugin>
+
+       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.2.7</version>
+       </plugin>
+
        <plugin>
         <!-- configuration of the source feature generation, is activated in features/pom -->
         <groupId>org.eclipse.tycho.extras</groupId>


### PR DESCRIPTION
In the most recent versions of Maven these warnings are now errors