### PR TITLE
[Build] Set Java Compiler's -release option instead of -source + -target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,7 @@
     <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 
 	<!-- pin the source code compatibility to 11 for the sake of backward compatibility -->
-    <maven.compiler.source>11</maven.compiler.source>
-
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
 
     <!-- Enable java assertions during junit test runs. -->
     <!-- The "enableAssertions" property is only available in the maven-surefire plugin. -->


### PR DESCRIPTION
Using the --release option instead --source plus --target is more convenient (just one option) and more powerful (checks also that now newer Java API is used even if the executing JDK is newer).