### PR TITLE
[Build] Unify build output and classpath configurations

### DIFF
--- a/plugins/de.cau.cs.kieler.kgraph.text.ide/.classpath
+++ b/plugins/de.cau.cs.kieler.kgraph.text.ide/.classpath
@@ -5,5 +5,5 @@
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.kgraph.text.ui/.classpath
+++ b/plugins/de.cau.cs.kieler.kgraph.text.ui/.classpath
@@ -2,8 +2,8 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="src" path="src-gen/"/>
-	<classpathentry kind="src" path="xtend-gen/"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="xtend-gen"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.kgraph.text.ui/build.properties
+++ b/plugins/de.cau.cs.kieler.kgraph.text.ui/build.properties
@@ -1,6 +1,7 @@
 source.. = src/,\
            src-gen/,\
            xtend-gen/
+output.. = bin/
 bin.includes = META-INF/,\
                .,\
                about.html,\

--- a/plugins/de.cau.cs.kieler.kgraph.text/.classpath
+++ b/plugins/de.cau.cs.kieler.kgraph.text/.classpath
@@ -2,8 +2,8 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="src" path="src-gen/"/>
-	<classpathentry kind="src" path="xtend-gen/"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src-gen"/>
+	<classpathentry kind="src" path="xtend-gen"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.kgraph.text/build.properties
+++ b/plugins/de.cau.cs.kieler.kgraph.text/build.properties
@@ -1,6 +1,7 @@
 source.. = src/,\
            src-gen/,\
            xtend-gen/
+output.. = bin/
 bin.includes = model/generated/,\
                META-INF/,\
                about.html,\

--- a/plugins/de.cau.cs.kieler.klighd.ide/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.ide/.classpath
@@ -4,5 +4,5 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.incremental/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.incremental/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.kgraph/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.kgraph/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.krendering.extensions/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.krendering.extensions/.classpath
@@ -4,5 +4,5 @@
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.krendering/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.krendering/.classpath
@@ -2,8 +2,8 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="src" path="src-custom/"/>
-	<classpathentry kind="src" path="model/"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="src-custom"/>
+	<classpathentry kind="src" path="model"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.lsp/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/.classpath
@@ -29,5 +29,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.lsp/build.properties
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/build.properties
@@ -1,10 +1,10 @@
 source.. = src/,\
            xtend-gen/
+output.. = bin/
 bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                about.html
-               META-INF/,
 bin.excludes = **/*.xtend,\
                **/*.java._trace
 src.includes = about.html

--- a/plugins/de.cau.cs.kieler.klighd.piccolo.freehep/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo.freehep/.classpath
@@ -1,27 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="bin" path="src">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="lib" path="lib/freehep-graphics2d-2.3.jar" sourcepath="lib/src/freehep-graphics2d-2.3-sources.jar"/>
 	<classpathentry kind="lib" path="lib/freehep-graphicsbase-2.3.jar" sourcepath="lib/src/freehep-graphicsbase-2.3-sources.jar"/>
 	<classpathentry kind="lib" path="lib/freehep-graphicsio-2.3.jar" sourcepath="lib/src/freehep-graphicsio-2.3-sources.jar"/>
 	<classpathentry kind="lib" path="lib/freehep-graphicsio-svg-2.3.jar" sourcepath="lib/src/freehep-graphicsio-svg-2.3-sources.jar"/>
 	<classpathentry kind="lib" path="lib/freehep-graphicsio-tests-2.3.jar" sourcepath="lib/src/freehep-graphicsio-tests-2.3-sources.jar"/>
 	<classpathentry kind="lib" path="lib/freehep-io-2.2.2.jar" sourcepath="lib/src/freehep-io-2.2.2-sources.jar"/>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.piccolo/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/.classpath
@@ -3,5 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.setup/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.setup/.classpath
@@ -1,21 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="target/classes" path="src">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.setup/build.properties
+++ b/plugins/de.cau.cs.kieler.klighd.setup/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
+output.. = bin/
 bin.includes = META-INF/,\
                .,\
                resources/

--- a/plugins/de.cau.cs.kieler.klighd.standalone/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd.standalone/.classpath
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/plugins/de.cau.cs.kieler.klighd.ui.view/build.properties
+++ b/plugins/de.cau.cs.kieler.klighd.ui.view/build.properties
@@ -1,5 +1,4 @@
-source.. = src/,\
-           xtend-gen/
+source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/plugins/de.cau.cs.kieler.klighd/.classpath
+++ b/plugins/de.cau.cs.kieler.klighd/.classpath
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Avoid using PDE's 'requiredPlugins'-container together with M2E's 'MAVEN2_CLASSPATH_CONTAINER'-container. When using both at the same time, one only ensures that Maven and PDE dependencies combined work, which is never a real use-case.

Also fix multiple build-configuration related warnings.