### PR TITLE
Set encoding of remaining project to UTF-8 explicitly to fix warnings

### DIFF
--- a/build/de.cau.cs.kieler.klighd.repository/.settings/org.eclipse.core.resources.prefs
+++ b/build/de.cau.cs.kieler.klighd.repository/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.batik.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.batik.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.draw2d.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.draw2d.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.freehep.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.freehep.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.ide.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.ide.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.sdk.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.sdk.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/de.cau.cs.kieler.klighd.view.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/de.cau.cs.kieler.klighd.view.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins-dev/de.cau.cs.kieler.klighd.kgx/.settings/org.eclipse.core.resources.prefs
+++ b/plugins-dev/de.cau.cs.kieler.klighd.kgx/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins-dev/de.cau.cs.kieler.klighd.offscreen.application/.settings/org.eclipse.core.resources.prefs
+++ b/plugins-dev/de.cau.cs.kieler.klighd.offscreen.application/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.piccolo.batik/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo.batik/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.piccolo.draw2d/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo.draw2d/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.ui.contrib3x/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.ui.contrib3x/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.ui.emf/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.ui.emf/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.ui.view/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.ui.view/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.ui.wizard/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.ui.wizard/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/de.cau.cs.kieler.klighd.ui/.settings/org.eclipse.core.resources.prefs
+++ b/plugins/de.cau.cs.kieler.klighd.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/de.cau.cs.kieler.klighd.piccolo.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/de.cau.cs.kieler.klighd.piccolo.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/test/de.cau.cs.kieler.klighd.test/.settings/org.eclipse.core.resources.prefs
+++ b/test/de.cau.cs.kieler.klighd.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Without an explicit encoding a warning is created: 'Project XYZ has no explicit encoding'