### PR TITLE
Add fuzziness to softwrapping label manager.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/internal/macrolayout/KlighdDiagramLayoutConnector.java
@@ -797,7 +797,6 @@ public class KlighdDiagramLayoutConnector implements IDiagramLayoutConnector {
     private void shapeLayoutToLayoutGraph(
             final KShapeLayout sourceShapeLayout, final ElkShape targetShape) {
 
-        // Attention: Layout options are transfered by the {@link KGraphPropertyLayoutConfig}
         targetShape.setLocation(sourceShapeLayout.getXpos(), sourceShapeLayout.getYpos());
         targetShape.setDimensions(sourceShapeLayout.getWidth(), sourceShapeLayout.getHeight());
     }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/SoftWrappingLabelManager.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/SoftWrappingLabelManager.java
@@ -37,17 +37,13 @@ import de.cau.cs.kieler.klighd.util.KlighdProperties;
  */
 public class SoftWrappingLabelManager extends AbstractKlighdLabelManager {
 
-    /** Amount of line overhang that is permitted in percent of the effevtiveTargetWidth 
-     * 
-     * */
-    
     /**
-     * Returns the amount of line overhang that is permitted in percent of the effevtiveTargetWidth.
-     * @param label The ElkLabel for which the fuzzyness is requested.
-     * @return The fuzzyness
+     * Returns the amount of line overhang that is permitted in percent of the effectiveTargetWidth.
+     * @param label The ElkLabel for which the fuzziness is requested.
+     * @return The fuzziness
      */
-    public double getFuzzyness(final ElkLabel label) {
-        return label.getProperty(KlighdProperties.SOFTWRAPPING_FUZZYNESS);
+    public double getFuzziness(final ElkLabel label) {
+        return label.getProperty(KlighdProperties.SOFTWRAPPING_FUZZINESS);
     }
     
     @Override
@@ -84,24 +80,26 @@ public class SoftWrappingLabelManager extends AbstractKlighdLabelManager {
                 } while (lineWidth < effectiveTargetWidth && currWordIndex < words.length);
 
                 // Check whether next line would be below the fuzzy threshold
-                int previewWordIndex = currWordIndex;
-                if (previewWordIndex < words.length) {
-                    String previewLineText = words[previewWordIndex];
-                    testText = previewLineText;
-                    do {
-                        previewLineText = testText;
-                        if (previewWordIndex < words.length - 1) {
-                            testText = previewLineText + " " + words[++previewWordIndex];
-                        } else {
-                            testText = " ";
-                            previewWordIndex++;
+                if (getFuzziness(label) > 0) {
+                    int previewWordIndex = currWordIndex;
+                    if (previewWordIndex < words.length) {
+                        String previewLineText = words[previewWordIndex];
+                        testText = previewLineText;
+                        do {
+                            previewLineText = testText;
+                            if (previewWordIndex < words.length - 1) {
+                                testText = previewLineText + " " + words[++previewWordIndex];
+                            } else {
+                                testText = " ";
+                                previewWordIndex++;
+                            }
+                            lineWidth = PlacementUtil.estimateTextSize(font, testText).getWidth();
+                        } while (lineWidth < effectiveTargetWidth && previewWordIndex < words.length);
+                        if (lineWidth < effectiveTargetWidth * getFuzziness(label)) {
+                            // next line would contain too much whitespace so append it to this line
+                            currWordIndex = previewWordIndex;
+                            currentLineText += " " + previewLineText;
                         }
-                        lineWidth = PlacementUtil.estimateTextSize(font, testText).getWidth();
-                    } while (lineWidth < effectiveTargetWidth && previewWordIndex < words.length);
-                    if (lineWidth < effectiveTargetWidth * getFuzzyness(label)) {
-                        // next line would contain too much whitespace so append it to this line
-                        currWordIndex = previewWordIndex;
-                        currentLineText += " " + previewLineText;
                     }
                 }
                 

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/SoftWrappingLabelManager.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/SoftWrappingLabelManager.java
@@ -16,11 +16,11 @@
  */
 package de.cau.cs.kieler.klighd.labels.management;
 
+import org.eclipse.elk.core.options.CoreOptions;
 import org.eclipse.elk.graph.ElkLabel;
 import org.eclipse.swt.graphics.FontData;
 
 import de.cau.cs.kieler.klighd.microlayout.PlacementUtil;
-import de.cau.cs.kieler.klighd.util.KlighdProperties;
 
 /**
  * Label manager which soft wraps the text so it fits a certain width. Soft wrapping only inserts
@@ -43,7 +43,7 @@ public class SoftWrappingLabelManager extends AbstractKlighdLabelManager {
      * @return The fuzziness
      */
     public double getFuzziness(final ElkLabel label) {
-        return label.getProperty(KlighdProperties.SOFTWRAPPING_FUZZINESS);
+        return label.getProperty(CoreOptions.SOFTWRAPPING_FUZZINESS);
     }
     
     @Override
@@ -95,6 +95,7 @@ public class SoftWrappingLabelManager extends AbstractKlighdLabelManager {
                             }
                             lineWidth = PlacementUtil.estimateTextSize(font, testText).getWidth();
                         } while (lineWidth < effectiveTargetWidth && previewWordIndex < words.length);
+                        lineWidth = PlacementUtil.estimateTextSize(font, previewLineText).getWidth();
                         if (lineWidth < effectiveTargetWidth * getFuzziness(label)) {
                             // next line would contain too much whitespace so append it to this line
                             currWordIndex = previewWordIndex;

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/SoftWrappingLabelManager.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/labels/management/SoftWrappingLabelManager.java
@@ -85,22 +85,24 @@ public class SoftWrappingLabelManager extends AbstractKlighdLabelManager {
 
                 // Check whether next line would be below the fuzzy threshold
                 int previewWordIndex = currWordIndex;
-                String previewLineText = words[previewWordIndex];
-                testText = previewLineText;
-                do {
-                    previewLineText = testText;
-                    if (previewWordIndex < words.length - 1) {
-                        testText = previewLineText + " " + words[++previewWordIndex];
-                    } else {
-                        testText = " ";
-                        previewWordIndex++;
+                if (previewWordIndex < words.length) {
+                    String previewLineText = words[previewWordIndex];
+                    testText = previewLineText;
+                    do {
+                        previewLineText = testText;
+                        if (previewWordIndex < words.length - 1) {
+                            testText = previewLineText + " " + words[++previewWordIndex];
+                        } else {
+                            testText = " ";
+                            previewWordIndex++;
+                        }
+                        lineWidth = PlacementUtil.estimateTextSize(font, testText).getWidth();
+                    } while (lineWidth < effectiveTargetWidth && previewWordIndex < words.length);
+                    if (lineWidth < effectiveTargetWidth * getFuzzyness(label)) {
+                        // next line would contain too much whitespace so append it to this line
+                        currWordIndex = previewWordIndex;
+                        currentLineText += " " + previewLineText;
                     }
-                    lineWidth = PlacementUtil.estimateTextSize(font, testText).getWidth();
-                } while (lineWidth < effectiveTargetWidth && previewWordIndex < words.length);
-                if (lineWidth < effectiveTargetWidth * getFuzzyness(label)) {
-                    // next line would contain too much whitespace so append it to this line
-                    currWordIndex = previewWordIndex;
-                    currentLineText += " " + previewLineText;
                 }
                 
                 // No more words fit so the line is added to the result

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -429,11 +429,11 @@ public final class KlighdProperties {
             new Property<KVector>("klighd.roundedRectangle.autopadding", null);
     
     /**
-     * Determines the amount of fuzzyness to be used when performing softwrapping on labels.
+     * Determines the amount of fuzziness to be used when performing softwrapping on labels.
      * The value expresses the percent of overhang that is permitted for each line.
      * If the next line would take up less space than this threshold, it is appended to the
      * current line instead of being placed in a new line.
      */
-    public static final IProperty<Double> SOFTWRAPPING_FUZZYNESS = 
+    public static final IProperty<Double> SOFTWRAPPING_FUZZINESS = 
             new Property<Double>("klighd.softwrapping.fuzzyness",0.0);
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -427,4 +427,13 @@ public final class KlighdProperties {
      */
     public static final IProperty<KVector> ROUNDED_RECTANGLE_AUTOPADDING = 
             new Property<KVector>("klighd.roundedRectangle.autopadding", null);
+    
+    /**
+     * Determines the amount of fuzzyness to be used when performing softwrapping on labels.
+     * The value expresses the percent of overhang that is permitted for each line.
+     * If the next line would take up less space than this threshold, it is appended to the
+     * current line instead of being placed in a new line.
+     */
+    public static final IProperty<Double> SOFTWRAPPING_FUZZYNESS = 
+            new Property<Double>("klighd.softwrapping.fuzzyness",0.0);
 }

--- a/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
+++ b/plugins/de.cau.cs.kieler.klighd/src/de/cau/cs/kieler/klighd/util/KlighdProperties.java
@@ -427,13 +427,4 @@ public final class KlighdProperties {
      */
     public static final IProperty<KVector> ROUNDED_RECTANGLE_AUTOPADDING = 
             new Property<KVector>("klighd.roundedRectangle.autopadding", null);
-    
-    /**
-     * Determines the amount of fuzziness to be used when performing softwrapping on labels.
-     * The value expresses the percent of overhang that is permitted for each line.
-     * If the next line would take up less space than this threshold, it is appended to the
-     * current line instead of being placed in a new line.
-     */
-    public static final IProperty<Double> SOFTWRAPPING_FUZZINESS = 
-            new Property<Double>("klighd.softwrapping.fuzzyness",0.0);
 }


### PR DESCRIPTION
Add a property that should be set on Labels and expand the softwrapping label manager to fuzzily check whether the next line could be placed on the current line.
This reduces wasted whitespace.