### PR TITLE
Revert "[Build] Set Java Compiler's -release option instead of -source + -target"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,9 @@
     <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
 
 	<!-- pin the source code compatibility to 11 for the sake of backward compatibility -->
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+
+    <maven.compiler.target>11</maven.compiler.target>
 
     <!-- Enable java assertions during junit test runs. -->
     <!-- The "enableAssertions" property is only available in the maven-surefire plugin. -->


### PR DESCRIPTION
Reverts kieler/KLighD#214

Seems like the PR #214 did lead to errors not occuring in the PR build due to Javadoc building:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.5.0:jar (attach-javadocs) on project de.cau.cs.kieler.klighd.kgraph: MavenReportException: Error while generating Javadoc: 
Error:  Exit code: 1
Error: [ERROR] error: module org.eclipse.emf.ecore.xmi reads package org.eclipse.core.runtime from both org.eclipse.equinox.common and org.eclipse.equinox.registry
Error: [ERROR] error: module org.eclipse.emf.ecore.xmi reads package org.eclipse.core.internal.runtime from both org.eclipse.equinox.common and org.eclipse.core.runtime
Error: [ERROR] error: module org.eclipse.emf.ecore.xmi reads package org.eclipse.core.runtime from both org.eclipse.equinox.common and org.eclipse.core.runtime
Error: [ERROR] error: module org.eclipse.elk.graph reads package org.eclipse.core.runtime from both org.eclipse.equinox.common and org.eclipse.equinox.registry
Error: [ERROR] error: module org.eclipse.elk.graph reads package org.eclipse.core.internal.runtime from both org.eclipse.equinox.common and org.eclipse.core.runtime
[...]
```

Reverting this PR.