### PR TITLE
lsp: allow to expand nodes that have no children so that the expanded rendering is shown.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphDiagramGenerator.xtend
@@ -279,7 +279,7 @@ class KGraphDiagramGenerator implements IDiagramGenerator {
         
         nodeElement.children.addAll(createPorts(node.ports))
         nodeElement.children.addAll(createLabels(node.labels))
-        if ((!node.children.empty) && isExpanded) {
+        if (isExpanded) {
             renderingContextData.setProperty(KlighdInternalProperties.POPULATED, true)
             nodeElement.children.addAll(createNodesAndPrepareEdges(node.children, nodeElement))
         } else {


### PR DESCRIPTION
This is now consistent with the Eclipse implementation - any expanded node gets the "populated" property regardless of if it has children. This fixes the "Details" button in the EObjectFallbackSynthesis to properly show the details again.