### PR TITLE
Turn around setBounds calls in KLighDCancas to avoid a circular call from Eclipse 2025-03.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/KlighdCanvas.java
+++ b/plugins/de.cau.cs.kieler.klighd.piccolo/src/de/cau/cs/kieler/klighd/piccolo/internal/KlighdCanvas.java
@@ -352,11 +352,10 @@ public class KlighdCanvas extends Composite implements PComponent {
      * @param rectangle the new bounds
      */
     public void setBounds(final Rectangle rectangle) {
-        this.setBounds(rectangle.x, rectangle.y, rectangle.width, rectangle.height);
-    }
-
-    @Override
-    public void setBounds(final int x, final int y, final int newWidth, final int newHeight) {
+        int x = rectangle.x;
+        int y = rectangle.y;
+        int newWidth = rectangle.width;
+        int newHeight = rectangle.height;
         // extracted the following check from the super implementation
         //  in order to allow to roll back most of the customizations in the Piccolo2D code some day
         if (newWidth == 0 || newHeight == 0) {
@@ -373,8 +372,14 @@ public class KlighdCanvas extends Composite implements PComponent {
                 resizeBackBuffer(newWidth, newHeight);
             }
 
-            super.setBounds(x, y, newWidth, newHeight);
+            super.setBounds(rectangle);
         }
+    }
+
+    @Override
+    public void setBounds(final int x, final int y, final int newWidth, final int newHeight) {
+        this.setBounds(new Rectangle(x, y, newWidth, newHeight));
+        
     }
 
     private void resizeBackBuffer(final int newWidth, final int newHeight) {


### PR DESCRIPTION
This PR turns around the call of setBounds(Rectangle) to setBounds(int, int, int, int) that worked until Eclipse 2024-12 so that now setBounds(int, int, int, int) calls setBounds(Rectangle) with the same behavior, to match the API change of the Canvas class in Eclipse 2025-03.

This should fix #225 and not break the behavior in previous editions.