### PR TITLE
use LSP's showMessage feature instead of custom extension.

### DIFF
--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLanguageClient.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLanguageClient.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2020 by
+ * Copyright 2020-2026 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -29,6 +29,8 @@ interface KGraphLanguageClient extends LanguageClient {
     
     /**
      * Send to client if some message should be displayed. {@code type} is one of "info", "warn", and "error".
+     * 
+     * @deprecated Use the default LSP "window/showMessage" notification instead.
      */
     @JsonNotification("general/sendMessage")
     def void sendMessage(String message, String type)

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLanguageServerExtension.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/KGraphLanguageServerExtension.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2018-2025 by
+ * Copyright 2018-2026 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -48,6 +48,8 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.lsp4j.DocumentHighlight
 import org.eclipse.lsp4j.DocumentHighlightParams
 import org.eclipse.lsp4j.InitializeParams
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.sprotty.ActionMessage
 import org.eclipse.sprotty.DiagramOptions
@@ -616,7 +618,7 @@ class KGraphLanguageServerExtension extends SyncDiagramLanguageServer
     
     override sendError(String message) {
         if (this.kgraphLanguageClient !== null) {
-            this.kgraphLanguageClient.sendMessage(LSPUtil.escapeHtml(message), "error")
+            this.kgraphLanguageClient.showMessage(new MessageParams(MessageType.Error, LSPUtil.escapeHtml(message)))
             return true
         }
         return false
@@ -624,7 +626,7 @@ class KGraphLanguageServerExtension extends SyncDiagramLanguageServer
     
     override sendWarning(String message) {
         if (this.kgraphLanguageClient !== null) {
-            this.kgraphLanguageClient.sendMessage(LSPUtil.escapeHtml(message), "warn")
+            this.kgraphLanguageClient.showMessage(new MessageParams(MessageType.Warning, LSPUtil.escapeHtml(message)))
             return true
         }
         return false
@@ -632,7 +634,7 @@ class KGraphLanguageServerExtension extends SyncDiagramLanguageServer
     
     override sendInfo(String message) {
         if (this.kgraphLanguageClient !== null) {
-            this.kgraphLanguageClient.sendMessage(LSPUtil.escapeHtml(message), "info")
+            this.kgraphLanguageClient.showMessage(new MessageParams(MessageType.Info, LSPUtil.escapeHtml(message)))
             return true
         }
         return false

--- a/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/launch/AbstractLsCreator.xtend
+++ b/plugins/de.cau.cs.kieler.klighd.lsp/src/de/cau/cs/kieler/klighd/lsp/launch/AbstractLsCreator.xtend
@@ -3,7 +3,7 @@
  * 
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2019-2021 by
+ * Copyright 2019-2026 by
  * + Kiel University
  *   + Department of Computer Science
  *     + Real-Time and Embedded Systems Group
@@ -41,6 +41,8 @@ import java.util.function.Function
 import org.apache.log4j.AsyncAppender
 import org.apache.log4j.Logger
 import org.eclipse.core.runtime.IStatus
+import org.eclipse.lsp4j.MessageParams
+import org.eclipse.lsp4j.MessageType
 import org.eclipse.lsp4j.jsonrpc.Launcher.Builder
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer
 import org.eclipse.lsp4j.services.LanguageClient
@@ -181,18 +183,18 @@ abstract class AbstractLsCreator implements ILsCreator {
         // Register a new status handler that forwards the messages to the client.
         Klighd.setStatusManager( [status, style |
             if (style !== IKlighdStatusManager.NONE) {
-                var String type
+                var MessageType type
                 switch (status.getSeverity()) {
                 case IStatus.INFO:
-                    type = "info"
+                    type = MessageType.Info
                 case IStatus.WARNING:
-                    type = "warn"
+                    type = MessageType.Warning
                 case IStatus.ERROR:
-                    type = "error"
+                    type = MessageType.Error
                 default:
                     return
                 }
-                languageClient.sendMessage(statusToMessage(status), type)
+                languageClient.showMessage(new MessageParams(type, statusToMessage(status)))
             }
         ])
     }


### PR DESCRIPTION
The custom general/sendMessage notification used to display KLighD messages on language server clients is not needed, as the LSP defines [its own message for that](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessage).
This PR uses that message instead and deprecates the old general/sendMessage notification.
Requires change from corresponding PR in klighd-vscode so that these messages are still shown in the CLI, does not break API otherwise.